### PR TITLE
workflow: add clippy and cargo-deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Deny
+        run: |
+          pushd vmm/sandbox && cargo install cargo-deny && cargo deny check && popd
+          pushd vmm/task && cargo deny check && popd
+          pushd shim && cargo deny check && popd
+          pushd wasm && cargo deny check && popd
+          pushd quark && cargo deny check && popd
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
@@ -40,11 +47,11 @@ jobs:
           pushd quark && cargo +nightly fmt --all -- --check --files-with-diff && popd
       - name: Clippy
         run: |
-          pushd vmm/sandbox && cargo clippy --all-features && popd
-          pushd vmm/task && cargo clippy --all-features && popd
-          pushd shim && cargo clippy --all-features && popd
-          pushd wasm && cargo clippy --all-features && popd
-          pushd quark && cargo clippy --all-features && popd
+          pushd vmm/sandbox && cargo clippy --all-features -- -D warning && popd
+          pushd vmm/task && cargo clippy --all-features -- -D warning && popd
+          pushd shim && cargo clippy --all-features -- -D warning && popd
+          pushd wasm && cargo clippy --all-features -- -D warning && popd
+          pushd quark && cargo clippy --all-features -- -D warning && popd
   tests:
 
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 Cargo.lock
 **/src/api/*
 !**/src/api/mod.rs
+.cargo

--- a/quark/deny.toml
+++ b/quark/deny.toml
@@ -1,0 +1,20 @@
+[licenses]
+allow = [
+    "MIT",
+    "CC0-1.0",
+    "ISC",
+    "OpenSSL",
+    "Unlicense",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Zlib",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+
+unlicensed = "warn"
+default = "warn"
+
+private = { ignore = true }

--- a/shim/deny.toml
+++ b/shim/deny.toml
@@ -1,0 +1,20 @@
+[licenses]
+allow = [
+    "MIT",
+    "CC0-1.0",
+    "ISC",
+    "OpenSSL",
+    "Unlicense",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Zlib",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+
+unlicensed = "warn"
+default = "warn"
+
+private = { ignore = true }

--- a/vmm/sandbox/deny.toml
+++ b/vmm/sandbox/deny.toml
@@ -1,0 +1,20 @@
+[licenses]
+allow = [
+    "MIT",
+    "CC0-1.0",
+    "ISC",
+    "OpenSSL",
+    "Unlicense",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Zlib",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+
+unlicensed = "warn"
+default = "warn"
+
+private = { ignore = true }

--- a/vmm/task/deny.toml
+++ b/vmm/task/deny.toml
@@ -1,0 +1,20 @@
+[licenses]
+allow = [
+    "MIT",
+    "CC0-1.0",
+    "ISC",
+    "OpenSSL",
+    "Unlicense",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Zlib",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+
+unlicensed = "warn"
+default = "warn"
+
+private = { ignore = true }

--- a/wasm/deny.toml
+++ b/wasm/deny.toml
@@ -1,0 +1,20 @@
+[licenses]
+allow = [
+    "MIT",
+    "CC0-1.0",
+    "ISC",
+    "OpenSSL",
+    "Unlicense",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Zlib",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+
+unlicensed = "warn"
+default = "warn"
+
+private = { ignore = true }


### PR DESCRIPTION
adds a GitHub workflow that performs clippy linting and cargo-deny auditing on Rust code.

Fixes #12