### PR TITLE
workflow: add clippy and cargo-deny linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,17 @@ jobs:
   check:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3
+      - name: Deny
+        run: |
+          pushd vmm/sandbox && cargo install cargo-deny && cargo deny -L debug --all-features check && popd
+          pushd vmm/task && cargo deny -L debug --all-features check && popd
+          pushd shim && cargo deny -L debug --all-features check && popd
+          pushd wasm && cargo deny -L debug --all-features check && popd
+          pushd quark && cargo deny -L debug --all-features check && popd
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
@@ -40,11 +47,11 @@ jobs:
           pushd quark && cargo +nightly fmt --all -- --check --files-with-diff && popd
       - name: Clippy
         run: |
-          pushd vmm/sandbox && cargo clippy --all-features && popd
-          pushd vmm/task && cargo clippy --all-features && popd
-          pushd shim && cargo clippy --all-features && popd
-          pushd wasm && cargo clippy --all-features && popd
-          pushd quark && cargo clippy --all-features && popd
+          pushd vmm/sandbox && cargo clippy --all-features -- -D warnings && popd
+          pushd vmm/task && cargo clippy --all-features -- -D warnings && popd
+          pushd shim && cargo clippy --all-features -- -D warnings && popd
+          pushd wasm && cargo clippy --all-features -- -D warnings && popd
+          pushd quark && cargo clippy --all-features -- -D warnings && popd
   tests:
 
     runs-on: ubuntu-latest

--- a/quark/deny.toml
+++ b/quark/deny.toml
@@ -1,0 +1,274 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "warn"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "warn"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "ISC",
+    "Unlicense",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/quark/src/mount.rs
+++ b/quark/src/mount.rs
@@ -25,8 +25,8 @@ use lazy_static::lazy_static;
 use log::debug;
 use nix::{errno::Errno, libc, mount::MsFlags, NixPath};
 
-pub const MNT_NOFOLLOW: i32 = 0x8;
-pub const MNT_OPTION_MAX_LEN: usize = 4096;
+pub const _MNT_NOFOLLOW: i32 = 0x8;
+pub const _MNT_OPTION_MAX_LEN: usize = 4096;
 
 struct Flag {
     clear: bool,
@@ -224,7 +224,7 @@ lazy_static! {
     static ref MS_BIND_RO: MsFlags = MsFlags::MS_BIND.bitor(MsFlags::MS_RDONLY);
 }
 
-pub fn mount(
+pub fn _mount(
     fs_type: Option<&str>,
     source: Option<&str>,
     options: &[String],
@@ -233,7 +233,7 @@ pub fn mount(
     let (flags, data) = parse_options(options);
 
     let opt = data.join(",");
-    if opt.len() > MNT_OPTION_MAX_LEN {
+    if opt.len() > _MNT_OPTION_MAX_LEN {
         return Err(anyhow!("mount option is too long"));
     }
 
@@ -324,7 +324,7 @@ pub async fn bind_mount<T: AsRef<Path>>(source: T, target: &str, options: &[Stri
     Ok(())
 }
 
-pub fn unmount(target: &str, flags: i32) -> Result<()> {
+pub fn _unmount(target: &str, flags: i32) -> Result<()> {
     let res = target
         .with_nix_path(|cstr| unsafe { libc::umount2(cstr.as_ptr(), flags) })
         .map_err(|e| anyhow!("failed to umount {}, {}", target, e))?;

--- a/quark/src/sandbox.rs
+++ b/quark/src/sandbox.rs
@@ -51,7 +51,7 @@ pub struct QuarkSandboxer {
 }
 
 pub struct QuarkSandbox {
-    pub(crate) id: String,
+    pub(crate) _id: String,
     pub(crate) base_dir: String,
     pub(crate) data: SandboxData,
     pub(crate) status: SandboxStatus,
@@ -69,7 +69,7 @@ impl Sandboxer for QuarkSandboxer {
 
     async fn create(&self, id: &str, s: SandboxOption) -> Result<()> {
         let mut sandbox = QuarkSandbox {
-            id: id.to_string(),
+            _id: id.to_string(),
             base_dir: s.base_dir,
             data: s.sandbox,
             status: SandboxStatus::Created,
@@ -524,7 +524,7 @@ impl QuarkSandboxer {
     }
 }
 
-pub(crate) fn to_any(spec: &JsonSpec) -> Result<Any> {
+pub(crate) fn _to_any(spec: &JsonSpec) -> Result<Any> {
     let spec_vec =
         serde_json::to_vec(spec).map_err(|e| anyhow!("failed to parse sepc to json, {}", e))?;
     Ok(Any {

--- a/quark/src/utils.rs
+++ b/quark/src/utils.rs
@@ -67,7 +67,7 @@ pub async fn write_file_atomic<P: AsRef<Path>>(path: P, s: &[u8]) -> Result<()> 
         .map_err(|e| anyhow!("failed to rename file:{}, {}", tmp_path.display(), e).into())
 }
 
-pub fn bind_socket(socket_path: &str) -> Result<RawFd> {
+pub fn _bind_socket(socket_path: &str) -> Result<RawFd> {
     let fd = socket(
         AddressFamily::Unix,
         SockType::Stream,

--- a/shim/deny.toml
+++ b/shim/deny.toml
@@ -1,0 +1,274 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "warn"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "warn"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "ISC",
+    "Unlicense",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/shim/src/io.rs
+++ b/shim/src/io.rs
@@ -133,11 +133,11 @@ impl VsockIO {
 
 impl ToString for VsockIO {
     fn to_string(&self) -> String {
-        return if self.sock_path.is_empty() {
+        if self.sock_path.is_empty() {
             String::new()
         } else {
             format!("{}{}:{}", HVSOCK_PREFIX, self.sock_path, self.port)
-        };
+        }
     }
 }
 

--- a/vmm/sandbox/deny.toml
+++ b/vmm/sandbox/deny.toml
@@ -1,0 +1,274 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "warn"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "warn"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "ISC",
+    "Unlicense",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/vmm/sandbox/src/cloud_hypervisor/devices/device.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/devices/device.rs
@@ -26,6 +26,7 @@ pub struct PhysicalDevice {
 
 impl_device_no_bus!(PhysicalDevice);
 
+#[allow(dead_code)]
 impl PhysicalDevice {
     pub fn new(path: &str, id: &str) -> Self {
         Self {

--- a/vmm/sandbox/src/container/handler/io.rs
+++ b/vmm/sandbox/src/container/handler/io.rs
@@ -78,7 +78,7 @@ where
         tokio::fs::remove_file(&io_file_path)
             .await
             .unwrap_or_default();
-        let mut container = sandbox.container_mut(&self.container_id)?;
+        let container = sandbox.container_mut(&self.container_id)?;
         container.io_devices = vec![];
         container.data.io = None;
         Ok(())

--- a/vmm/sandbox/src/device.rs
+++ b/vmm/sandbox/src/device.rs
@@ -101,7 +101,7 @@ impl Bus {
 
     #[allow(dead_code)]
     pub fn attach<T: Device>(&mut self, device: &T) -> Result<usize> {
-        for (index, mut s) in self.slots.iter_mut().enumerate() {
+        for (index, s) in self.slots.iter_mut().enumerate() {
             if let SlotStatus::Empty = s.status {
                 s.status = SlotStatus::Occupied(device.id());
                 return Ok(index);

--- a/vmm/sandbox/src/main.rs
+++ b/vmm/sandbox/src/main.rs
@@ -16,8 +16,6 @@ limitations under the License.
 
 use std::path::Path;
 
-use log::info;
-
 use crate::{
     config::Config,
     kata_config::KataConfig,
@@ -108,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         .format_timestamp_micros()
         .init();
     #[cfg(feature = "qemu")]
+    #[allow(unused_variables)]
     let sandboxer: KuasarSandboxer<QemuVMFactory, QemuHooks> = {
         // for compatible of kata config
         let config_path = std::env::var("KATA_CONFIG_PATH").unwrap_or_else(|_| {
@@ -125,10 +124,10 @@ async fn main() -> anyhow::Result<()> {
     };
 
     #[cfg(feature = "stratovirt")]
+    #[allow(unused_variables)]
     let sandboxer: KuasarSandboxer<StratoVirtVMFactory, StratoVirtHooks> = {
         let os_args: Vec<_> = std::env::args_os().collect();
         let mut config_path = "/var/lib/kuasar/config_stratovirt.toml".to_string();
-        let mut dir = None;
         for i in 0..os_args.len() {
             if os_args[i].to_str().unwrap() == "--config" {
                 config_path = os_args[i + 1].to_str().unwrap().to_string()
@@ -138,7 +137,6 @@ async fn main() -> anyhow::Result<()> {
                 if !Path::new(&dir_path).exists() {
                     tokio::fs::create_dir_all(&dir_path).await.unwrap();
                 }
-                dir = Some(dir_path);
             }
         }
         let path = Path::new(&config_path);
@@ -152,6 +150,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     #[cfg(feature = "cloud_hypervisor")]
+    #[allow(unused_variables)]
     let sandboxer: KuasarSandboxer<CloudHypervisorVMFactory, CloudHypervisorHooks> = {
         let os_args: Vec<_> = std::env::args_os().collect();
 

--- a/vmm/sandbox/src/network/address.rs
+++ b/vmm/sandbox/src/network/address.rs
@@ -35,10 +35,9 @@ pub struct CniIPAddress {
     pub mask: String,
 }
 
-impl Into<String> for &mut CniIPAddress {
-    // TODO: support family for ipv6
-    fn into(self) -> String {
-        format!("{}/{}", self.address, self.mask)
+impl From<&mut CniIPAddress> for String {
+    fn from(ip: &mut CniIPAddress) -> String {
+        format!("{}/{}", ip.address, ip.mask)
     }
 }
 
@@ -69,9 +68,9 @@ impl From<String> for IpNet {
     }
 }
 
-impl Into<String> for IpNet {
-    fn into(self) -> String {
-        format!("{}/{}", self.addr_string(), self.prefix_len)
+impl From<IpNet> for String {
+    fn from(ip_net: IpNet) -> String {
+        format!("{}/{}", ip_net.addr_string(), ip_net.prefix_len)
     }
 }
 

--- a/vmm/sandbox/src/network/link.rs
+++ b/vmm/sandbox/src/network/link.rs
@@ -53,7 +53,9 @@ use crate::{
 
 const DEVICE_DRIVER_VFIO: &str = "vfio-pci";
 
+#[allow(dead_code)]
 const SIOCETHTOOL: u64 = 0x8946;
+#[allow(dead_code)]
 const ETHTOOL_GDRVINFO: u32 = 0x00000003;
 
 const TUNSETIFF: u64 = 0x400454ca;
@@ -62,12 +64,14 @@ const TUNSETPERSIST: u64 = 0x400454cb;
 ioctl_write_ptr_bad!(ioctl_tun_set_iff, TUNSETIFF, ifreq);
 ioctl_write_ptr_bad!(ioctl_tun_set_persist, TUNSETPERSIST, u64);
 
+#[allow(dead_code)]
 #[repr(C)]
 pub struct Ifreq {
     ifr_name: [u8; 16],
     ifr_data: *mut libc::c_void,
 }
 
+#[allow(dead_code)]
 #[repr(C)]
 pub struct EthtoolDrvInfo {
     cmd: u32,
@@ -227,13 +231,11 @@ impl NetworkInterface {
                     for info in infos {
                         if let Info::Data(d) = info {
                             intf.r#type = d.into();
-                        } else if let Info::Kind(k) = info {
+                        } else if let Info::Kind(InfoKind::Veth) = info {
                             // for veth, there is no Info::Data, but SlaveKind and SlaveData
                             // so we have to get the type from Info::Kind
-                            if let InfoKind::Veth = k {
-                                intf.queue = queue;
-                                intf.r#type = LinkType::Veth
-                            }
+                            intf.queue = queue;
+                            intf.r#type = LinkType::Veth;
                         }
                     }
                 }
@@ -409,6 +411,7 @@ impl NetworkInterface {
     }
 }
 
+#[allow(dead_code)]
 fn get_bdf_for_eth(if_name: &str) -> Result<String> {
     if if_name.len() > 16 {
         return Err(anyhow!("the interface name length is larger than 16").into());
@@ -541,6 +544,7 @@ fn create_tap_device(tap_name: &str, mut queue: u32) -> Result<Vec<OwnedFd>> {
     Ok(fds)
 }
 
+#[allow(dead_code)]
 async fn get_pci_driver(bdf: &str) -> Result<String> {
     let driver_path = format!("/sys/bus/pci/devices/{}/driver", bdf);
     let driver_dest = tokio::fs::read_link(driver_path).await?;

--- a/vmm/sandbox/src/network/netlink.rs
+++ b/vmm/sandbox/src/network/netlink.rs
@@ -19,7 +19,9 @@ use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, N
 use netlink_packet_route::{RtnlMessage, TcMessage};
 use rtnetlink::{try_nl, Error, Handle};
 
+#[allow(dead_code)]
 const HANDLE_INGRESS: u32 = 0xfffffff1;
+#[allow(dead_code)]
 const HANDLE_TC_FILTER: u32 = 0xffff0000;
 
 pub struct QDiscAddRequest {
@@ -27,6 +29,7 @@ pub struct QDiscAddRequest {
     message: TcMessage,
 }
 
+#[allow(dead_code)]
 impl QDiscAddRequest {
     pub(crate) fn new(handle: Handle) -> Self {
         QDiscAddRequest {
@@ -62,11 +65,13 @@ impl QDiscAddRequest {
     }
 }
 
+#[allow(dead_code)]
 pub struct TrafficFilterSetRequest {
     handle: Handle,
     message: TcMessage,
 }
 
+#[allow(dead_code)]
 impl TrafficFilterSetRequest {
     pub(crate) fn new(handle: Handle, ifindex: i32) -> Self {
         let mut message = TcMessage::default();

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -44,7 +44,7 @@ use crate::{
 
 pub const KUASAR_GUEST_SHARE_DIR: &str = "/run/kuasar/storage/containers/";
 
-macro_rules! monitor {
+macro_rules! _monitor {
     ($sb:ident) => {
         tokio::spawn(async move {
             let mut rx = {
@@ -465,9 +465,9 @@ pub struct SandboxConfig {}
 #[serde(deny_unknown_fields)]
 pub struct StaticDeviceSpec {
     #[serde(default)]
-    pub(crate) host_path: Vec<String>,
+    pub(crate) _host_path: Vec<String>,
     #[serde(default)]
-    pub(crate) bdf: Vec<String>,
+    pub(crate) _bdf: Vec<String>,
     #[allow(dead_code)]
     #[deprecated]
     #[serde(default)]

--- a/vmm/sandbox/src/stratovirt/config.rs
+++ b/vmm/sandbox/src/stratovirt/config.rs
@@ -27,6 +27,7 @@ use crate::{
 pub(crate) const MACHINE_TYPE_Q35: &str = "q35";
 #[allow(dead_code)]
 pub(crate) const MACHINE_TYPE_PC: &str = "pc";
+#[allow(dead_code)]
 pub(crate) const MACHINE_TYPE_VIRT: &str = "virt";
 #[allow(dead_code)]
 pub(crate) const MACHINE_TYPE_PSERIES: &str = "pseries";
@@ -101,11 +102,8 @@ impl StratoVirtVMConfig {
         if self.common.kernel_params.is_empty() {
             result.kernel.kernel_params = DEFAULT_KERNEL_PARAMS.to_string();
         } else {
-            result.kernel.kernel_params = format!(
-                "{} {}",
-                DEFAULT_KERNEL_PARAMS,
-                self.common.kernel_params.to_string()
-            );
+            result.kernel.kernel_params =
+                format!("{} {}", DEFAULT_KERNEL_PARAMS, self.common.kernel_params);
         }
 
         result.global_params = vec![Global {
@@ -150,7 +148,7 @@ pub struct QmpSocket {
 impl ToCmdLineParams for QmpSocket {
     fn to_cmdline_params(&self, hyphen: &str) -> Vec<String> {
         vec![
-            format!("{}{}", hyphen, self.param_key.to_string()),
+            format!("{}{}", hyphen, self.param_key),
             format!("{}:{},server,nowait", self.r#type, self.name,),
         ]
     }

--- a/vmm/sandbox/src/stratovirt/devices/block.rs
+++ b/vmm/sandbox/src/stratovirt/devices/block.rs
@@ -33,6 +33,7 @@ use crate::{
     stratovirt::{devices::HotAttachable, qmp_client::QmpClient},
 };
 
+#[allow(dead_code)]
 pub const VIRTIO_BLK_DRIVER: &str = "virtio-blk";
 
 #[derive(CmdLineParams, Debug, Clone)]
@@ -98,7 +99,7 @@ impl HotAttachable for VirtioBlockDevice {
     async fn execute_hot_detach(&self, client: &QmpClient) -> Result<()> {
         debug!("hot detach device {}", self.id);
         let device_id = format!("virtio-{}", self.id());
-        client.delete_device(&*device_id).await?;
+        client.delete_device(&device_id).await?;
         client.execute(self.to_blockdev_del()).await?;
         Ok(())
     }
@@ -150,7 +151,7 @@ impl VirtioBlockDevice {
     fn to_device_add(&self, rp_id: &str) -> device_add {
         let mut args = Dictionary::new();
         args.insert("drive".to_string(), Value::from(self.id()));
-        let addr = format!("0x0");
+        let addr = "0x0".to_string();
         args.insert("addr".to_string(), Value::from(addr));
 
         let driver = "virtio-blk-pci".to_string();

--- a/vmm/sandbox/src/stratovirt/devices/char.rs
+++ b/vmm/sandbox/src/stratovirt/devices/char.rs
@@ -58,7 +58,9 @@ impl CharDevice {
 }
 
 mod tests {
+    #[allow(unused_imports)]
     use super::CharDevice;
+    #[allow(unused_imports)]
     use crate::param::ToCmdLineParams;
 
     #[test]

--- a/vmm/sandbox/src/stratovirt/devices/console.rs
+++ b/vmm/sandbox/src/stratovirt/devices/console.rs
@@ -44,7 +44,9 @@ impl VirtConsole {
 }
 
 mod tests {
+    #[allow(unused_imports)]
     use super::VirtConsole;
+    #[allow(unused_imports)]
     use crate::{
         device::Transport,
         param::ToCmdLineParams,

--- a/vmm/sandbox/src/stratovirt/devices/mod.rs
+++ b/vmm/sandbox/src/stratovirt/devices/mod.rs
@@ -47,10 +47,15 @@ pub(crate) const DEFAULT_SERIAL_DEVICE_ID: &str = "virtio-serial0";
 pub(crate) const DEFAULT_CONSOLE_DEVICE_ID: &str = "virtio-console0";
 pub(crate) const DEFAULT_CONSOLE_CHARDEV_ID: &str = "charconsole0";
 
+#[allow(dead_code)]
 pub(crate) const VIRTIO_RND_DEVICE_ADDR: usize = 1;
+#[allow(dead_code)]
 pub(crate) const VIRTIO_SERIAL_CONSOLE_ADDR: usize = 2;
+#[allow(dead_code)]
 pub(crate) const VHOST_VSOCK_ADDR: usize = 3;
+#[allow(dead_code)]
 pub(crate) const VHOST_USER_FS_ADDR: usize = 4;
+#[allow(dead_code)]
 pub(crate) const ROOTPORT_PCI_START_ADDR: usize = 5;
 
 pub trait StratoVirtDevice: Device + ToCmdLineParams + GetAndSetDeviceAddr {}

--- a/vmm/sandbox/src/stratovirt/devices/rootport.rs
+++ b/vmm/sandbox/src/stratovirt/devices/rootport.rs
@@ -48,7 +48,7 @@ impl RootPort {
             addr: "".to_string(),
             multi_function: multi_func,
             device_id: "".to_string(),
-            index: index,
+            index,
         }
     }
 }
@@ -56,21 +56,11 @@ impl RootPort {
 impl_device_no_bus!(RootPort);
 impl_set_get_device_addr!(RootPort);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PCIERootPorts {
     pub(crate) id: String,
     pub(crate) bus: Bus,
     pub(crate) root_ports: Vec<RootPort>,
-}
-
-impl Default for PCIERootPorts {
-    fn default() -> PCIERootPorts {
-        PCIERootPorts {
-            id: Default::default(),
-            bus: Bus::default(),
-            root_ports: Default::default(),
-        }
-    }
 }
 
 impl_device!(PCIERootPorts);

--- a/vmm/sandbox/src/stratovirt/devices/virtio_net.rs
+++ b/vmm/sandbox/src/stratovirt/devices/virtio_net.rs
@@ -96,38 +96,74 @@ impl_device_no_bus!(VirtioNetDevice);
 impl_set_get_device_addr!(VirtioNetDevice);
 
 impl VirtioNetDevice {
-    pub fn new(
-        id: &str,
-        name: Option<String>,
-        mac_address: &str,
-        transport: Transport,
-        fds: Vec<RawFd>,
-        enable_vhost: bool,
-        vhostfds: Vec<RawFd>,
-        bus: Option<String>,
-    ) -> Self {
-        let driver = transport.to_driver(VIRTIO_NET_DRIVER);
-        let multi_queue = !fds.is_empty();
-        Self {
+    pub fn new() -> Self {
+        VirtioNetDevice {
             r#type: NetType::Tap,
-            transport,
-            driver,
-            id: id.to_string(),
-            device_id: format!("virtio-net-{}", id),
-            vhost: enable_vhost,
-            vhostfds,
-            fds,
-            ifname: name,
-            pci_bus: bus,
+            transport: Transport::Pci,
+            driver: "".to_string(),
+            id: "".to_string(),
+            device_id: "".to_string(),
+            vhost: false,
+            vhostfds: vec![],
+            fds: vec![],
+            ifname: None,
+            pci_bus: None,
             addr: "".to_string(),
             script: None,
             down_script: None,
-            mac_address: mac_address.to_string(),
-            multi_queue,
+            mac_address: "".to_string(),
+            multi_queue: false,
             disable_modern: None,
             romfile: None,
             queues: None,
         }
+    }
+
+    pub fn id(mut self, id: &str) -> Self {
+        self.id = id.to_string();
+        self.device_id = format!("virtio-net-{}", self.id);
+        self
+    }
+
+    pub fn name(mut self, name: &str) -> Self {
+        self.ifname = Some(name.to_string());
+        self
+    }
+
+    pub fn mac_address(mut self, mac_address: &str) -> Self {
+        self.mac_address = mac_address.to_string();
+        self
+    }
+
+    pub fn transport(mut self, transport: Transport) -> Self {
+        self.transport = transport;
+        self.driver = self.transport.to_driver(VIRTIO_NET_DRIVER);
+        self
+    }
+
+    pub fn fds(mut self, fds: Vec<RawFd>) -> Self {
+        self.fds = fds;
+        self.multi_queue = !self.fds.is_empty();
+        self
+    }
+
+    pub fn vhost(mut self, vhost: bool) -> Self {
+        self.vhost = vhost;
+        self
+    }
+
+    pub fn vhostfds(mut self, vhostfds: Vec<RawFd>) -> Self {
+        self.vhostfds = vhostfds;
+        self
+    }
+
+    pub fn bus(mut self, bus: Option<String>) -> Self {
+        self.pci_bus = bus;
+        self
+    }
+
+    pub fn build(self) -> VirtioNetDevice {
+        self
     }
 }
 

--- a/vmm/sandbox/src/stratovirt/devices/vsock.rs
+++ b/vmm/sandbox/src/stratovirt/devices/vsock.rs
@@ -52,7 +52,7 @@ impl VSockDevice {
         Self {
             driver: transport.to_driver(VHOST_VSOCK_DRIVER),
             id: format!("vsock-{}", context_id),
-            context_id: context_id,
+            context_id,
             bus: bus.to_string(),
             addr: "".to_string(),
             vhostfd: vhost_fd,

--- a/vmm/sandbox/src/stratovirt/factory.rs
+++ b/vmm/sandbox/src/stratovirt/factory.rs
@@ -116,7 +116,7 @@ impl VMFactory for StratoVirtVMFactory {
         let virtiofs_chardev = CharDevice::new("socket", &chardev_id, &absolute_virtiofs_sock);
         vm.attach_device(virtiofs_chardev);
         let vhost_user_fs_device = VhostUserFs::new(
-            &*format!("vhost-user-fs-{}", id),
+            &format!("vhost-user-fs-{}", id),
             Transport::Pci,
             &chardev_id,
             DEFAULT_MOUNT_TAG_NAME,

--- a/vmm/sandbox/src/stratovirt/hooks.rs
+++ b/vmm/sandbox/src/stratovirt/hooks.rs
@@ -36,7 +36,7 @@ impl StratoVirtHooks {
 
 #[async_trait]
 impl Hooks<StratoVirtVM> for StratoVirtHooks {
-    async fn pre_start(&self, sandbox: &mut KuasarSandbox<StratoVirtVM>) -> Result<()> {
+    async fn pre_start(&self, _sandbox: &mut KuasarSandbox<StratoVirtVM>) -> Result<()> {
         // TODO
         Ok(())
     }

--- a/vmm/sandbox/src/utils.rs
+++ b/vmm/sandbox/src/utils.rs
@@ -79,6 +79,7 @@ pub fn get_resources(data: &SandboxData) -> Option<&LinuxContainerResources> {
         .and_then(|l| l.resources.as_ref())
 }
 
+#[allow(dead_code)]
 pub fn get_total_resources(data: &SandboxData) -> Option<LinuxContainerResources> {
     return data
         .config
@@ -96,6 +97,7 @@ pub fn get_total_resources(data: &SandboxData) -> Option<LinuxContainerResources
         });
 }
 
+#[allow(dead_code)]
 fn merge_resources(
     resource1: &LinuxContainerResources,
     resource2: &LinuxContainerResources,
@@ -167,6 +169,7 @@ fn merge_resources(
     }
 }
 
+#[allow(dead_code)]
 fn merge_cpusets(cpusets1: &str, cpusets2: &str) -> Result<String> {
     let cpuset1_parts = cpuset_parts(cpusets1)?;
     let cpuset2_parts = cpuset_parts(cpusets2)?;
@@ -194,6 +197,7 @@ fn merge_cpusets(cpusets1: &str, cpusets2: &str) -> Result<String> {
         .join(","))
 }
 
+#[allow(dead_code)]
 fn merge_cpuset(base: (u32, u32), delta: (u32, u32)) -> (u32, u32) {
     let (mut low, mut high) = base;
     if delta.1 < low {
@@ -211,6 +215,7 @@ fn merge_cpuset(base: (u32, u32), delta: (u32, u32)) -> (u32, u32) {
     (low, high)
 }
 
+#[allow(dead_code)]
 fn cpuset_intersect(cpuset1: (u32, u32), cpuset2: (u32, u32)) -> bool {
     if cpuset2.1 < cpuset1.0 {
         return false;
@@ -221,6 +226,7 @@ fn cpuset_intersect(cpuset1: (u32, u32), cpuset2: (u32, u32)) -> bool {
     true
 }
 
+#[allow(dead_code)]
 fn cpuset_parts(cpuset: &str) -> Result<Vec<(u32, u32)>> {
     let mut cpuset1_parts = vec![];
     let c1 = cpuset.split(',');
@@ -230,6 +236,7 @@ fn cpuset_parts(cpuset: &str) -> Result<Vec<(u32, u32)>> {
     Ok(cpuset1_parts)
 }
 
+#[allow(dead_code)]
 fn cpuset_one_part(cpuset: &str) -> Result<(u32, u32)> {
     let parts = cpuset.split('-').collect::<Vec<&str>>();
     let low = parts[0]
@@ -246,6 +253,7 @@ fn cpuset_one_part(cpuset: &str) -> Result<(u32, u32)> {
     Ok((low, high))
 }
 
+#[allow(dead_code)]
 pub fn cpuset_tostring(cpuset: (u32, u32)) -> String {
     if cpuset.0 == cpuset.1 {
         return cpuset.0.to_string();

--- a/vmm/task/deny.toml
+++ b/vmm/task/deny.toml
@@ -1,0 +1,274 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "warn"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "warn"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "ISC",
+    "Unlicense",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/vmm/task/src/container.rs
+++ b/vmm/task/src/container.rs
@@ -205,7 +205,7 @@ impl KuasarFactory {
         // pivot_root could not work with initramfs
         match get_mount_type("/") {
             Ok(m_type) => {
-                if m_type == "rootfs".to_string() {
+                if m_type == *"rootfs" {
                     no_pivot_root = true;
                 }
             }

--- a/wasm/deny.toml
+++ b/wasm/deny.toml
@@ -1,0 +1,274 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "warn"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "warn"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "ISC",
+    "Unlicense",
+    "BSD-3-Clause",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
+    "Unicode-DFS-2016"
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/wasm/src/sandbox.rs
+++ b/wasm/src/sandbox.rs
@@ -44,7 +44,7 @@ pub struct WasmSandboxer {
 }
 
 pub struct WasmSandbox {
-    pub(crate) id: String,
+    pub(crate) _id: String,
     pub(crate) base_dir: String,
     pub(crate) data: SandboxData,
     pub(crate) status: SandboxStatus,
@@ -63,7 +63,7 @@ impl Sandboxer for WasmSandboxer {
 
     async fn create(&self, id: &str, s: SandboxOption) -> Result<()> {
         let sandbox = WasmSandbox {
-            id: id.to_string(),
+            _id: id.to_string(),
             base_dir: s.base_dir,
             data: s.sandbox,
             status: SandboxStatus::Created,

--- a/wasm/src/wasmedge.rs
+++ b/wasm/src/wasmedge.rs
@@ -65,12 +65,12 @@ pub struct ExecFactory {}
 pub struct WasmEdgeExecLifecycle {}
 
 pub struct WasmEdgeInitLifecycle {
-    opts: Options,
-    bundle: String,
+    _opts: Options,
+    _bundle: String,
     spec: Spec,
     prototype_vm: Vm,
     netns: String,
-    exit_signal: Arc<ExitSignal>,
+    _exit_signal: Arc<ExitSignal>,
 }
 
 pub struct WasmEdgeContainerFactory {
@@ -131,9 +131,9 @@ impl ContainerFactory<WasmEdgeContainer> for WasmEdgeContainerFactory {
             req.id(),
             stdio,
             WasmEdgeInitLifecycle {
-                opts: Default::default(),
-                bundle: req.bundle.to_string(),
-                exit_signal,
+                _opts: Default::default(),
+                _bundle: req.bundle.to_string(),
+                _exit_signal: exit_signal,
                 spec,
                 prototype_vm: self.prototype_vm.clone(),
                 netns,


### PR DESCRIPTION
adds a GitHub workflow that performs clippy linting and cargo-deny auditing on Rust code.

Fixes #12