### PR TITLE
support start startovirt vm with image

### DIFF
--- a/vmm/sandbox/src/stratovirt/devices/block.rs
+++ b/vmm/sandbox/src/stratovirt/devices/block.rs
@@ -44,6 +44,8 @@ pub struct VirtioBlockDevice {
     #[property(param = "drive")]
     #[property(param = "device", key = "drive")]
     pub id: String,
+    #[property(param = "device", key = "id")]
+    pub deviceid: String,
     #[property(param = "drive")]
     pub file: Option<String>,
     #[property(param = "drive")]
@@ -62,10 +64,17 @@ impl_device_no_bus!(VirtioBlockDevice);
 impl_set_get_device_addr!(VirtioBlockDevice);
 
 impl VirtioBlockDevice {
-    pub fn new(driver: &str, id: &str, file: Option<String>, read_only: Option<bool>) -> Self {
+    pub fn new(
+        driver: &str,
+        id: &str,
+        deviceid: &str,
+        file: Option<String>,
+        read_only: Option<bool>,
+    ) -> Self {
         Self {
             driver: driver.to_string(),
             id: id.to_string(),
+            deviceid: deviceid.to_string(),
             file,
             r#if: None,
             readonly: read_only,
@@ -190,6 +199,7 @@ mod tests {
         let virtio_blk_device = VirtioBlockDevice::new(
             VIRTIO_BLK_DRIVER,
             "drive-0",
+            "",
             Some("/dev/dm-8".to_string()),
             Some(false),
         );
@@ -216,6 +226,7 @@ mod tests {
         let virtio_blk_device = VirtioBlockDevice::new(
             VIRTIO_BLK_DRIVER,
             "drive-0",
+            "",
             Some("/dev/dm-8".to_string()),
             Some(false),
         );
@@ -236,6 +247,7 @@ mod tests {
         let virtio_blk_device = VirtioBlockDevice::new(
             VIRTIO_BLK_DRIVER,
             "drive-0",
+            "",
             Some("/dev/dm-8".to_string()),
             Some(false),
         );
@@ -256,6 +268,7 @@ mod tests {
         let virtio_blk_device = VirtioBlockDevice::new(
             VIRTIO_BLK_DRIVER,
             "drive-0",
+            "",
             Some("/dev/dm-8".to_string()),
             Some(false),
         );

--- a/vmm/sandbox/src/stratovirt/mod.rs
+++ b/vmm/sandbox/src/stratovirt/mod.rs
@@ -204,6 +204,7 @@ impl VM for StratoVirtVM {
                 let device = VirtioBlockDevice::new(
                     "",
                     &blk_info.id,
+                    "",
                     Some(blk_info.path),
                     Some(blk_info.read_only),
                 );

--- a/vmm/sandbox/src/vm.rs
+++ b/vmm/sandbox/src/vm.rs
@@ -100,7 +100,7 @@ impl Default for HypervisorCommonConfig {
             vcpus: 1,
             memory_in_mb: 1024,
             kernel_path: "/var/lib/kuasar/vmlinux.bin".to_string(),
-            image_path: "/var/lib/kuasar/kuasar.img".to_string(),
+            image_path: "".to_string(),
             initrd_path: "".to_string(),
             kernel_params: "".to_string(),
         }


### PR DESCRIPTION
After this , we support using kuasar to boot startovirt VM with **block image as rootfs**.
Specifify image_path in config file to try it~