### PR TITLE
[vmm]: fix cert_file_path variable in the build scripts

### DIFF
--- a/vmm/scripts/image/centos/build_rootfs.sh
+++ b/vmm/scripts/image/centos/build_rootfs.sh
@@ -40,7 +40,7 @@ make_vmm_task() {
 
     # update cert file under internal proxy scenario
     if [ -f "${cert_file_path}" ]; then
-        cp /kuasar/huawei.crt /etc/pki/ca-trust/source/anchors/
+        cp ${cert_file_path} /etc/pki/ca-trust/source/anchors/
         update-ca-trust extract
     fi
 


### PR DESCRIPTION
reason: use cert_file_path variable to refer the cert file in the build container instead of a contant value.