### PR TITLE
[vmm]: support configure log_level in the config file

### DIFF
--- a/vmm/sandbox/config_clh.toml
+++ b/vmm/sandbox/config_clh.toml
@@ -1,4 +1,6 @@
 [sandbox]
+log_level = "info"
+
 [hypervisor]
 path = "/usr/local/bin/cloud-hypervisor"
 vcpus = 1

--- a/vmm/sandbox/config_stratovirt.toml
+++ b/vmm/sandbox/config_stratovirt.toml
@@ -1,4 +1,5 @@
 [sandbox]
+log_level = "info"
 
 [hypervisor]
 path = "/usr/bin/stratovirt"

--- a/vmm/sandbox/src/kata_config.rs
+++ b/vmm/sandbox/src/kata_config.rs
@@ -211,7 +211,7 @@ impl KataConfig {
             .hypervisor
             .get(h)
             .ok_or_else(|| Error::NotFound(format!("no hypervisor config of {} in kata", h)))?;
-        Ok(SandboxConfig {})
+        Ok(SandboxConfig::default())
     }
 }
 

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -96,6 +96,10 @@ where
             sandboxes: Arc::new(Default::default()),
         }
     }
+
+    pub fn log_level(&self) -> &str {
+        &self.config.log_level
+    }
 }
 
 impl<F, H> KuasarSandboxer<F, H>
@@ -459,7 +463,10 @@ where
 }
 
 #[derive(Default, Debug, Deserialize)]
-pub struct SandboxConfig {}
+pub struct SandboxConfig {
+    #[serde(default)]
+    pub log_level: String,
+}
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
fix #35

reason: Add 'sandbox.log_level' field in the config file to support configure the vmm-sandboxer process log level.