### PR TITLE
optimize sandbox directory structure

### DIFF
--- a/vmm/common/src/lib.rs
+++ b/vmm/common/src/lib.rs
@@ -20,7 +20,8 @@ pub mod api;
 pub mod mount;
 pub mod storage;
 
-pub const KUASAR_STATE_DIR: &str = "/run/kuasar/state/";
+pub const KUASAR_STATE_DIR: &str = "/run/kuasar/state";
 
 pub const IO_FILE_PREFIX: &str = "io";
 pub const STORAGE_FILE_PREFIX: &str = "storage";
+pub const SHARED_DIR_SUFFIX: &str = "shared";

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -27,6 +27,7 @@ use tokio::{
     sync::watch::{channel, Receiver, Sender},
     task::JoinHandle,
 };
+use vmm_common::SHARED_DIR_SUFFIX;
 
 use crate::{
     cloud_hypervisor::{
@@ -73,7 +74,7 @@ impl CloudHypervisorVM {
 
         let mut virtiofsd_config = vm_config.virtiofsd.clone();
         virtiofsd_config.socket_path = format!("{}/virtiofs.sock", base_dir);
-        virtiofsd_config.shared_dir = base_dir.to_string();
+        virtiofsd_config.shared_dir = format!("{}/{}", base_dir, SHARED_DIR_SUFFIX);
         Self {
             id: id.to_string(),
             config,

--- a/vmm/sandbox/src/container/handler/spec.rs
+++ b/vmm/sandbox/src/container/handler/spec.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use anyhow::anyhow;
 use async_trait::async_trait;
 use containerd_sandbox::error::Error;
+use vmm_common::SHARED_DIR_SUFFIX;
 
 use crate::{
     container::handler::Handler, sandbox::KuasarSandbox, utils::write_file_atomic, vm::VM,
@@ -60,7 +61,10 @@ where
         }
         let spec_str = serde_json::to_string(spec)
             .map_err(|e| anyhow!("failed to parse spec in sandbox, {}", e))?;
-        let bundle = format!("{}/{}", sandbox.base_dir, self.container_id);
+        let bundle = format!(
+            "{}/{}/{}",
+            sandbox.base_dir, SHARED_DIR_SUFFIX, self.container_id
+        );
         tokio::fs::create_dir_all(&*bundle)
             .await
             .map_err(|e| anyhow!("failed to create container bundle, {}", e))?;
@@ -75,7 +79,10 @@ where
         &self,
         sandbox: &mut KuasarSandbox<T>,
     ) -> containerd_sandbox::error::Result<()> {
-        let bundle = format!("{}/{}", sandbox.base_dir, self.container_id);
+        let bundle = format!(
+            "{}/{}/{}",
+            sandbox.base_dir, SHARED_DIR_SUFFIX, self.container_id
+        );
         tokio::fs::remove_dir_all(&*bundle)
             .await
             .map_err(|e| anyhow!("failed to remove container bundle, {}", e))?;

--- a/vmm/sandbox/src/container/handler/spec.rs
+++ b/vmm/sandbox/src/container/handler/spec.rs
@@ -61,17 +61,8 @@ where
         }
         let spec_str = serde_json::to_string(spec)
             .map_err(|e| anyhow!("failed to parse spec in sandbox, {}", e))?;
-        let bundle = format!(
-            "{}/{}/{}",
-            sandbox.base_dir, SHARED_DIR_SUFFIX, self.container_id
-        );
-        tokio::fs::create_dir_all(&*bundle)
-            .await
-            .map_err(|e| anyhow!("failed to create container bundle, {}", e))?;
-        let config_path = format!("{}/{}", bundle, CONFIG_FILE_NAME);
+        let config_path = format!("{}/{}", container.data.bundle, CONFIG_FILE_NAME);
         write_file_atomic(config_path, &spec_str).await?;
-        let container = sandbox.container_mut(&self.container_id)?;
-        container.data.bundle = bundle;
         Ok(())
     }
 

--- a/vmm/sandbox/src/qemu/factory.rs
+++ b/vmm/sandbox/src/qemu/factory.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use containerd_sandbox::{error::Error, SandboxOption};
 use tokio::fs::create_dir_all;
 use uuid::Uuid;
+use vmm_common::SHARED_DIR_SUFFIX;
 
 use crate::{
     device::Transport,
@@ -138,7 +139,7 @@ impl VMFactory for QemuVMFactory {
         }
 
         // share fs
-        let share_fs_path = s.base_dir.to_string();
+        let share_fs_path = format!("{}/{}", s.base_dir, SHARED_DIR_SUFFIX);
         create_dir_all(&*share_fs_path).await?;
         match self.default_config.share_fs {
             ShareFsType::Virtio9P => {

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -32,7 +32,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::{Mutex, RwLock},
 };
-use vmm_common::{api::sandbox_ttrpc::SandboxServiceClient, storage::Storage};
+use vmm_common::{api::sandbox_ttrpc::SandboxServiceClient, storage::Storage, SHARED_DIR_SUFFIX};
 
 use crate::{
     client::{client_check, client_update_interfaces, client_update_routes, new_sandbox_client},
@@ -294,7 +294,7 @@ where
     async fn remove_container(&mut self, id: &str) -> Result<()> {
         self.deference_container_storages(id).await?;
 
-        let bundle = format!("{}/{}", self.base_dir, id);
+        let bundle = format!("{}/{}/{}", self.base_dir, SHARED_DIR_SUFFIX, id);
         if let Err(e) = tokio::fs::remove_dir_all(&*bundle).await {
             if e.kind() != ErrorKind::NotFound {
                 return Err(anyhow!("failed to remove bundle {}, {}", bundle, e).into());

--- a/vmm/sandbox/src/storage/mod.rs
+++ b/vmm/sandbox/src/storage/mod.rs
@@ -28,7 +28,7 @@ pub use utils::*;
 use vmm_common::{
     mount::{bind_mount, unmount, MNT_NOFOLLOW},
     storage::{Storage, DRIVEREPHEMERALTYPE},
-    KUASAR_STATE_DIR,
+    KUASAR_STATE_DIR, SHARED_DIR_SUFFIX,
 };
 
 use crate::{
@@ -158,7 +158,7 @@ where
         } else {
             m.source.clone()
         };
-        let host_dest = format!("{}/{}", self.base_dir, &storage_id);
+        let host_dest = format!("{}/{}/{}", self.base_dir, SHARED_DIR_SUFFIX, &storage_id);
         debug!("bind mount storage for mount {:?}, dest: {}", m, &host_dest);
         let source_path = Path::new(&*source);
         if source_path.is_dir() {
@@ -186,7 +186,7 @@ where
             driver_options: vec![],
             fstype: "bind".to_string(),
             options: vec![],
-            mount_point: format!("{}{}", KUASAR_STATE_DIR, &storage_id),
+            mount_point: format!("{}/{}", KUASAR_STATE_DIR, &storage_id),
         };
 
         storage.refer(container_id);
@@ -206,7 +206,7 @@ where
                 m
             )));
         }
-        let host_dest = format!("{}/{}", self.base_dir, &storage_id);
+        let host_dest = format!("{}/{}/{}", self.base_dir, SHARED_DIR_SUFFIX, &storage_id);
         debug!("overlay mount storage for {:?}, dest: {}", m, &host_dest);
         tokio::fs::create_dir_all(&host_dest).await?;
         mount_rootfs(Some(&m.r#type), Some(&m.source), &m.options, &host_dest)
@@ -224,7 +224,7 @@ where
             driver_options: vec![],
             fstype: "bind".to_string(),
             options: vec![],
-            mount_point: format!("{}{}", KUASAR_STATE_DIR, &storage_id),
+            mount_point: format!("{}/{}", KUASAR_STATE_DIR, &storage_id),
         };
 
         storage.refer(container_id);
@@ -288,7 +288,7 @@ where
         if device_id.is_some() {
             self.vm.hot_detach(&device_id.unwrap()).await?;
         } else if fs_type == "bind" {
-            let mount_point = format!("{}/{}", self.base_dir, id);
+            let mount_point = format!("{}/{}/{}", self.base_dir, SHARED_DIR_SUFFIX, id);
             unmount(&mount_point, MNT_DETACH | MNT_NOFOLLOW)?;
             if Path::new(&mount_point).is_dir() {
                 tokio::fs::remove_dir(&mount_point).await.map_err(|e| {

--- a/vmm/sandbox/src/stratovirt/factory.rs
+++ b/vmm/sandbox/src/stratovirt/factory.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use containerd_sandbox::SandboxOption;
 use tokio::fs::create_dir_all;
 use uuid::Uuid;
+use vmm_common::SHARED_DIR_SUFFIX;
 
 use super::devices::{
     block::{VirtioBlockDevice, VIRTIO_BLK_DRIVER},
@@ -122,7 +123,7 @@ impl VMFactory for StratoVirtVMFactory {
         vm.agent_socket = format!("vsock://{}:1024", cid);
 
         //share fs, stratovirt only support virtiofs share
-        let share_fs_path = s.base_dir.to_string();
+        let share_fs_path = format!("{}/{}", s.base_dir, SHARED_DIR_SUFFIX);
         create_dir_all(&share_fs_path).await?;
         let absolute_virtiofs_sock = format!("{}/virtiofs.sock", s.base_dir);
         let chardev_id = format!("virtio-fs-{}", id);
@@ -141,6 +142,7 @@ impl VMFactory for StratoVirtVMFactory {
         vm.create_vitiofs_daemon(
             self.default_config.virtiofsd_conf.path.as_str(),
             s.base_dir.as_str(),
+            share_fs_path.as_str(),
         );
 
         // set pcie-root-ports for hotplugging

--- a/vmm/sandbox/src/stratovirt/mod.rs
+++ b/vmm/sandbox/src/stratovirt/mod.rs
@@ -487,12 +487,12 @@ impl StratoVirtVM {
         Err(Error::ResourceExhausted("slot of rootport".to_string()))
     }
 
-    fn create_vitiofs_daemon(&mut self, daemon_path: &str, base_dir: &str) {
+    fn create_vitiofs_daemon(&mut self, daemon_path: &str, base_dir: &str, shared_path: &str) {
         self.virtiofs_daemon = Some(VirtiofsDaemon {
             path: daemon_path.to_string(),
             log_path: format!("{}/virtiofs.log", base_dir),
             socket_path: format!("{}/virtiofs.sock", base_dir),
-            shared_dir: base_dir.to_string(),
+            shared_dir: shared_path.to_string(),
             pid: None,
         });
     }


### PR DESCRIPTION
1. As we just need to mount guest needed directory and files to guest, other files like console sock and sandbox.json should not be mounted into guest, so we create a shared directory to store those needed by guest and mount it only.

after optimizing:
![image](https://github.com/kuasar-io/kuasar/assets/35406510/d91e4fa7-689e-4dac-b3bc-d67656a1b4db)

2. create bundle directory earlier
Before this, container bundle directory was initialized and created in spec handler, but it was used by storage handler and io handler which before spec handler, bundle directory was still "" in storage handler and io handler, which caused files were created under "/". So we should initialize and create bundle directory in metadata add handler which is before all other ones.

