### PR TITLE
vmm-task:individually specify task.debug to enable debug_console

### DIFF
--- a/docs/vmm/README.md
+++ b/docs/vmm/README.md
@@ -115,6 +115,33 @@ Jul 13 15:33:41 node vmm-sandboxer[3619585]: [2023-07-13T07:33:41.644358Z ERROR 
 Jul 13 15:33:41 node vmm-sandboxer[3619585]: [2023-07-13T07:33:41.742550Z INFO  containerd_sandbox::rpc] shutdown sandbox 31e668050c2031e9e7243720eaa8264c42b0283007e419948689cac2badb71cd
 ```
 
+# Developer  Guide
+
+## Set up a debug console
+
+Kuasar vmm supports setting up a shell debug console by adding `task.debug` to kernel_params in config file, this requires the guest image to include /bin/bash.
+
+```toml
+[hypervisor]
+  kernel_params = "task.debug"
+```
+
+After starting pod, get the `vsock guest-cid` from vm process:
+
+```bash
+$ ps -ef | grep stratovirt | grep 5cbcf744949d8 
+/usr/bin/stratovirt -name sandbox-5cbcf744949d8500e7159d6bd1e3894211f475549c0be15d9c60d3c502c7ede3 ...
+-device vhost-vsock-pci,id=vsock-395568061,guest-cid=395568061,bus=pcie.0,addr=0x3,vhostfd=3 
+...
+```
+
+Then developers could enter the guest os debug console shell environment by:
+
+```bash
+# ncat --vsock <guest-cid> <debug-console>
+$ ncat --vsock 395568061 1025
+```
+
 # Note
 
 Please note that this guide only teach you how to build kuasar from source code, if you want to run the kuasar, cloud hypervisor and virtiofsd are also needed!

--- a/vmm/task/src/config.rs
+++ b/vmm/task/src/config.rs
@@ -19,6 +19,7 @@ use tokio::fs::read_to_string;
 
 const SHAREFS_TYPE: &str = "task.sharefs_type";
 const LOG_LEVEL: &str = "task.log_level";
+const TASK_DEBUG: &str = "task.debug";
 
 macro_rules! parse_cmdline {
     ($param:ident, $key:ident, $field:expr) => {
@@ -40,6 +41,7 @@ macro_rules! parse_cmdline {
 pub struct TaskConfig {
     pub(crate) sharefs_type: String,
     pub(crate) log_level: String,
+    pub(crate) debug: bool,
 }
 
 impl Default for TaskConfig {
@@ -47,6 +49,7 @@ impl Default for TaskConfig {
         TaskConfig {
             sharefs_type: "9p".to_string(),
             log_level: "info".to_string(),
+            debug: false,
         }
     }
 }
@@ -62,6 +65,7 @@ impl TaskConfig {
             let param: Vec<&str> = p.split('=').collect();
             parse_cmdline!(param, SHAREFS_TYPE, config.sharefs_type, String::from);
             parse_cmdline!(param, LOG_LEVEL, config.log_level, String::from);
+            parse_cmdline!(param, TASK_DEBUG, config.debug);
         }
         Ok(config)
     }

--- a/vmm/task/src/main.rs
+++ b/vmm/task/src/main.rs
@@ -147,8 +147,7 @@ async fn main() {
             warn!("sharefs_type should be either 9p or virtiofs");
         }
     }
-    // TODO reuse log_level temporarily, maybe we should have a config named by "task.debug"
-    if config.log_level == "debug" {
+    if config.debug {
         debug!("listen vsock port 1025 for debug console");
         if let Err(e) = listen_debug_console("vsock://-1:1025").await {
             error!("failed to listen debug console port, {:?}", e);


### PR DESCRIPTION
Before this we reuse "task.log_level" to determine whether listening debug console port, which is not so good, individually specifying task.debug to enable debug_console is needed.