### PR TITLE
quark: add kuasar-quark systemd service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,5 +81,7 @@ install-wasm:
 
 install-quark:
 	@install -p -m 550 bin/quark-sandboxer ${DEST_DIR}${BIN_DIR}/quark-sandboxer
+	@install -d -m 750 ${DEST_DIR}${SYSTEMD_SERVICE_DIR}
+	@install -p -m 640 quark/service/kuasar-quark.service ${DEST_DIR}${SYSTEMD_SERVICE_DIR}/kuasar-quark.service
 
 install: all install-vmm install-wasm install-quark

--- a/quark/service/kuasar-quark.service
+++ b/quark/service/kuasar-quark.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kuasar Quark sandboxer daemon process
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/quark-sandboxer --listen /run/quark-sandboxer.sock --dir /var/lib/kuasar-quark
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+Delegate=yes
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The kuasar-quark process should be running as a systemd service.