### PR TITLE
[wasm] remove SIGTERM and SIGINT signal handling

### DIFF
--- a/wasm/src/main.rs
+++ b/wasm/src/main.rs
@@ -41,8 +41,7 @@ mod wasmtime;
 async fn main() -> anyhow::Result<()> {
     env_logger::builder().format_timestamp_micros().init();
     tokio::spawn(async move {
-        let signals = Signals::new([libc::SIGTERM, libc::SIGINT, libc::SIGPIPE, libc::SIGCHLD])
-            .expect("new signal failed");
+        let signals = Signals::new([libc::SIGPIPE, libc::SIGCHLD]).expect("new signal failed");
         handle_signals(signals).await;
     });
 
@@ -57,9 +56,6 @@ async fn handle_signals(signals: Signals) {
     let mut signals = signals.fuse();
     while let Some(sig) = signals.next().await {
         match sig {
-            libc::SIGTERM | libc::SIGINT => {
-                debug!("received {}", sig);
-            }
             libc::SIGCHLD => loop {
                 // Note: see comment at the counterpart in synchronous/mod.rs for details.
                 match wait::waitpid(Some(Pid::from_raw(-1)), Some(WaitPidFlag::WNOHANG)) {


### PR DESCRIPTION
Remove SIGTERM and SIGINT signal handling. Shutdown when received them.