### PR TITLE
ci: fix cargo clippy warnings

### DIFF
--- a/quark/src/sandbox.rs
+++ b/quark/src/sandbox.rs
@@ -148,13 +148,13 @@ impl Sandboxer for QuarkSandboxer {
     }
 
     async fn sandbox(&self, id: &str) -> Result<Arc<Mutex<Self::Sandbox>>> {
-        return Ok(self
+        Ok(self
             .sandboxes
             .read()
             .await
             .get(id)
             .ok_or_else(|| Error::NotFound(id.to_string()))?
-            .clone());
+            .clone())
     }
 
     async fn stop(&self, id: &str, _force: bool) -> Result<()> {
@@ -210,10 +210,9 @@ impl Sandbox for QuarkSandbox {
     }
 
     async fn container(&self, id: &str) -> Result<&Self::Container> {
-        return self
-            .containers
+        self.containers
             .get(id)
-            .ok_or(Error::NotFound(format!("no container id {} found", id)));
+            .ok_or(Error::NotFound(format!("no container id {} found", id)))
     }
 
     async fn append_container(&mut self, id: &str, option: ContainerOption) -> Result<()> {

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -253,7 +253,7 @@ impl VM for CloudHypervisorVM {
     }
 
     async fn wait_channel(&self) -> Option<Receiver<(u32, i128)>> {
-        return self.wait_chan.clone();
+        self.wait_chan.clone()
     }
 
     async fn vcpus(&self) -> Result<VcpuThreads> {

--- a/vmm/sandbox/src/qemu/mod.rs
+++ b/vmm/sandbox/src/qemu/mod.rs
@@ -212,7 +212,7 @@ impl VM for QemuVM {
     }
 
     async fn hot_attach(&mut self, device_info: DeviceInfo) -> Result<(BusType, String)> {
-        return match device_info {
+        match device_info {
             DeviceInfo::Block(blk_info) => {
                 let device = VirtioBlockDevice::new(
                     "",
@@ -259,7 +259,7 @@ impl VM for QemuVM {
                 // address is not import for char devices as guest will find the device by the name
                 Ok((BusType::PCI, char_info.name.clone()))
             }
-        };
+        }
     }
 
     async fn hot_detach(&mut self, id: &str) -> Result<()> {
@@ -300,7 +300,7 @@ impl VM for QemuVM {
     }
 
     async fn wait_channel(&self) -> Option<Receiver<(u32, i128)>> {
-        return self.wait_chan.clone();
+        self.wait_chan.clone()
     }
 
     async fn vcpus(&self) -> Result<VcpuThreads> {

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -284,13 +284,13 @@ where
     }
 
     async fn sandbox(&self, id: &str) -> Result<Arc<Mutex<Self::Sandbox>>> {
-        return Ok(self
+        Ok(self
             .sandboxes
             .read()
             .await
             .get(id)
             .ok_or_else(|| Error::NotFound(id.to_string()))?
-            .clone());
+            .clone())
     }
 
     async fn stop(&self, id: &str, force: bool) -> Result<()> {
@@ -384,7 +384,7 @@ where
     }
 
     async fn exit_signal(&self) -> Result<Arc<ExitSignal>> {
-        return Ok(self.exit_signal.clone());
+        Ok(self.exit_signal.clone())
     }
 
     fn get_data(&self) -> Result<SandboxData> {

--- a/vmm/sandbox/src/stratovirt/mod.rs
+++ b/vmm/sandbox/src/stratovirt/mod.rs
@@ -209,7 +209,7 @@ impl VM for StratoVirtVM {
     }
 
     async fn hot_attach(&mut self, device_info: DeviceInfo) -> Result<(BusType, String)> {
-        return match device_info {
+        match device_info {
             DeviceInfo::Block(blk_info) => {
                 let device = VirtioBlockDevice::new(
                     "",
@@ -234,7 +234,7 @@ impl VM for StratoVirtVM {
             DeviceInfo::Char(_char_info) => Err(Error::Unimplemented(
                 "hot attach for char device".to_string(),
             )),
-        };
+        }
     }
 
     async fn hot_detach(&mut self, _id: &str) -> Result<()> {
@@ -252,7 +252,7 @@ impl VM for StratoVirtVM {
     }
 
     async fn wait_channel(&self) -> Option<Receiver<(u32, i128)>> {
-        return self.wait_chan.clone();
+        self.wait_chan.clone()
     }
 
     async fn vcpus(&self) -> Result<VcpuThreads> {

--- a/wasm/src/sandbox.rs
+++ b/wasm/src/sandbox.rs
@@ -88,13 +88,13 @@ impl Sandboxer for WasmSandboxer {
     }
 
     async fn sandbox(&self, id: &str) -> Result<Arc<Mutex<Self::Sandbox>>> {
-        return Ok(self
+        Ok(self
             .sandboxes
             .read()
             .await
             .get(id)
             .ok_or_else(|| Error::NotFound(id.to_string()))?
-            .clone());
+            .clone())
     }
 
     async fn stop(&self, id: &str, _force: bool) -> Result<()> {
@@ -212,9 +212,9 @@ impl Sandbox for WasmSandbox {
     }
 
     async fn container(&self, id: &str) -> Result<&Self::Container> {
-        return self.containers.get(id).ok_or(Error::NotFound(format!(
+        self.containers.get(id).ok_or(Error::NotFound(format!(
             "failed to find container by id {id}"
-        )));
+        )))
     }
 
     async fn append_container(&mut self, id: &str, option: ContainerOption) -> Result<()> {


### PR DESCRIPTION
Fix lint check warning introduced after upgrading to Rust clippy 0.1.72