### PR TITLE
vmm: support VFIO device

### DIFF
--- a/vmm/sandbox/src/cloud_hypervisor/client.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/client.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use std::{
     os::unix::net::UnixStream,
-    path::Path,
     thread::sleep,
     time::{Duration, SystemTime},
 };
@@ -24,7 +23,7 @@ use std::{
 use anyhow::anyhow;
 use api_client::{simple_api_command, simple_api_full_command_with_fds_and_response};
 use containerd_sandbox::error::Result;
-use log::{error, trace};
+use log::error;
 
 use crate::{
     cloud_hypervisor::devices::{block::DiskConfig, AddDeviceResponse, RemoveDeviceRequest},
@@ -38,25 +37,26 @@ pub struct ChClient {
 }
 
 impl ChClient {
-    pub fn new<P: AsRef<Path>>(socket_path: P) -> Result<Self> {
+    pub async fn new(socket_path: String) -> Result<Self> {
         let start_time = SystemTime::now();
-        loop {
+        tokio::task::spawn_blocking(move || loop {
             match UnixStream::connect(&socket_path) {
                 Ok(socket) => {
                     return Ok(Self { socket });
                 }
                 Err(e) => {
-                    trace!("failed to create client: {:?}", e);
                     if start_time.elapsed().unwrap().as_secs()
                         > CLOUD_HYPERVISOR_START_TIMEOUT_IN_SEC
                     {
-                        error!("failed to create client: {:?}", e);
+                        error!("failed to connect api server: {:?}", e);
                         return Err(anyhow!("timeout connect client, {}", e).into());
                     }
                     sleep(Duration::from_millis(10));
                 }
             }
-        }
+        })
+        .await
+        .map_err(|e| anyhow!("failed to spawn a task {}", e))?
     }
 
     pub fn hot_attach(&mut self, device_info: DeviceInfo) -> Result<String> {

--- a/vmm/sandbox/src/cloud_hypervisor/devices/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/devices/mod.rs
@@ -24,6 +24,7 @@ pub mod device;
 pub mod fs;
 pub mod pmem;
 pub mod rng;
+pub mod vfio;
 pub mod virtio_net;
 pub mod vsock;
 

--- a/vmm/sandbox/src/cloud_hypervisor/devices/vfio.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/devices/vfio.rs
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kuasar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use sandbox_derive::CmdLineParams;
+
+const VFIO_DEVICE_SYSFS_PATH: &str = "/sys/bus/pci/devices";
+
+#[derive(CmdLineParams, Debug, Clone)]
+#[params("device")]
+pub struct VfioDevice {
+    #[property(ignore)]
+    pub id: String,
+    pub(crate) path: String,
+}
+
+impl_device_no_bus!(VfioDevice);
+
+impl VfioDevice {
+    pub fn new(id: &str, bdf: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            path: format!("{}/{}", VFIO_DEVICE_SYSFS_PATH, bdf),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{cloud_hypervisor::devices::vfio::VfioDevice, param::ToParams};
+
+    #[test]
+    fn test_attr() {
+        let device = VfioDevice::new("", "0000:b4:05.1");
+        let params = device.to_params();
+        let property = params.get(0).unwrap();
+        assert_eq!(
+            property.get("path").unwrap(),
+            "/sys/bus/pci/devices/0000:b4:05.1"
+        );
+    }
+}

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -35,7 +35,9 @@ use crate::{
     cloud_hypervisor::{
         client::ChClient,
         config::{CloudHypervisorConfig, CloudHypervisorVMConfig, VirtiofsdConfig},
-        devices::{block::Disk, virtio_net::VirtioNetDevice, CloudHypervisorDevice},
+        devices::{
+            block::Disk, vfio::VfioDevice, virtio_net::VirtioNetDevice, CloudHypervisorDevice,
+        },
     },
     device::{BusType, DeviceInfo},
     impl_recoverable, load_config,
@@ -221,8 +223,9 @@ impl VM for CloudHypervisorVM {
                 );
                 self.add_device(device);
             }
-            DeviceInfo::Physical(_vfio_info) => {
-                todo!()
+            DeviceInfo::Physical(vfio_info) => {
+                let device = VfioDevice::new(&vfio_info.id, &vfio_info.bdf);
+                self.add_device(device);
             }
             DeviceInfo::VhostUser(_vhost_user_info) => {
                 todo!()

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -110,7 +110,7 @@ impl CloudHypervisorVM {
     }
 
     async fn create_client(&self) -> Result<ChClient> {
-        ChClient::new(&self.config.api_socket)
+        ChClient::new(self.config.api_socket.to_string()).await
     }
 
     fn get_client(&mut self) -> Result<&mut ChClient> {

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -125,7 +125,7 @@ impl CloudHypervisorVM {
         let mut cmd = tokio::process::Command::new(&self.virtiofsd_config.path);
         cmd.args(params.as_slice());
         debug!("start virtiofsd with cmdline: {:?}", cmd);
-        set_cmd_netns(&mut cmd, &self.netns)?;
+        set_cmd_netns(&mut cmd, self.netns.to_string())?;
         cmd.stderr(Stdio::piped());
         cmd.stdout(Stdio::piped());
         let child = cmd
@@ -164,7 +164,7 @@ impl VM for CloudHypervisorVM {
         cmd.args(params.as_slice());
 
         set_cmd_fd(&mut cmd, self.fds.to_vec())?;
-        set_cmd_netns(&mut cmd, &self.netns)?;
+        set_cmd_netns(&mut cmd, self.netns.to_string())?;
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
         debug!("start cloud hypervisor with cmdline: {:?}", cmd);

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -466,6 +466,10 @@ where
 
     async fn stop(&mut self, force: bool) -> Result<()> {
         match self.status {
+            // If sandbox is created but not running, no need to stop.
+            SandboxStatus::Created => {
+                return Ok(());
+            }
             SandboxStatus::Running(_) => {}
             SandboxStatus::Stopped(_, _) => {
                 return Ok(());


### PR DESCRIPTION
1. Support VFIO device in vmm.
2. Run libc::connect() in spawn_blocking to avoid blocking other task.
3. Return OK() if sandbox is in CREATED state.
4. Return io error in cmd pre_exec