### PR TITLE
build: Update repo before installation

### DIFF
--- a/vmm/scripts/image/build_image.sh
+++ b/vmm/scripts/image/build_image.sh
@@ -450,7 +450,7 @@ install_prerequisites() {
 		os_distro=$ID
 	fi
 	case "${os_distro}" in
-		ubuntu) apt-get install -y qemu-utils parted ;;
+		ubuntu) apt-get update && apt-get install -y qemu-utils parted ;;
 		centos) yum install -y qemu-img parted ;;
 		euleros) yum install -y qemu-img parted ;;
 		openEuler) yum install -y qemu-img parted ;;


### PR DESCRIPTION
In the [v0.5.0 release workflow:](https://github.com/kuasar-io/kuasar/actions/runs/7528597290/job/20511976902) , it failed with building vmm image as `apt-get install` met 404 error. Should update repo before install any packages.

Here is the result on my personal repo: https://github.com/Burning1020/kuasar/actions/runs/7536124247/job/20513086311