### PR TITLE
[vmm]: fix cargo test compilation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,6 @@ jobs:
       - name: Test
         env:
           RUST_BACKTRACE: full
+          RUSTFLAGS: -D warnings
         working-directory: ${{ matrix.directories }}
         run: sudo -E $(command -v cargo) test ${{ matrix.features }}

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -604,11 +604,7 @@ where
 
 // parse_dnsoptions parse DNS options into resolv.conf format content,
 // if none option is specified, will return empty with no error.
-fn parse_dnsoptions(
-    servers: &Vec<String>,
-    searches: &Vec<String>,
-    options: &Vec<String>,
-) -> String {
+fn parse_dnsoptions(servers: &[String], searches: &[String], options: &[String]) -> String {
     let mut resolv_content = String::new();
 
     if !searches.is_empty() {
@@ -694,7 +690,7 @@ mod tests {
 
         #[test]
         fn test_parse_empty_dns_option() {
-            let mut dns_test = DnsConfig::default();
+            let dns_test = DnsConfig::default();
             let resolv_content =
                 parse_dnsoptions(&dns_test.servers, &dns_test.searches, &dns_test.options);
             assert!(resolv_content.is_empty())

--- a/vmm/sandbox/src/stratovirt/devices/block.rs
+++ b/vmm/sandbox/src/stratovirt/devices/block.rs
@@ -190,9 +190,16 @@ impl VirtioBlockDevice {
 
 #[cfg(test)]
 mod tests {
-    use qapi::qmp::BlockdevOptions;
+    use serde_json::Value;
 
     use super::{VirtioBlockDevice, VIRTIO_BLK_DRIVER};
+
+    fn compare_json_strings(json_str1: &str, json_str2: &str) -> bool {
+        let value1: Value = serde_json::from_str(json_str1).unwrap();
+        let value2: Value = serde_json::from_str(json_str2).unwrap();
+
+        value1 == value2
+    }
 
     #[test]
     fn test_block_device_add_qmp_commands() {
@@ -212,13 +219,11 @@ mod tests {
         );
 
         let expected_params_str = r#"{"driver":"raw","read-only":false,"node-name":"drive-0","cache":{"direct":true},"file":{"driver":"file","filename":"/dev/dm-8"}}"#;
-        let expected_add_qmp_cmd: BlockdevOptions =
-            serde_json::from_str(expected_params_str).unwrap();
 
-        if let BlockdevOptions::raw { base, raw } = expected_add_qmp_cmd {
-            // TODO: compare the all elements
-            assert!(true);
-        }
+        assert!(compare_json_strings(
+            &blockdev_add_qmp_json_str,
+            expected_params_str
+        ));
     }
 
     #[test]
@@ -239,7 +244,10 @@ mod tests {
         );
 
         let expected_params_str = r#"{"driver":"virtio-blk-pci","id":"virtio-drive-0","bus":"pcie.1","addr":"0x0","drive":"drive-0"}"#;
-        assert!(true);
+        assert!(compare_json_strings(
+            &device_add_qmp_json_str,
+            expected_params_str
+        ));
     }
 
     #[test]

--- a/vmm/sandbox/src/stratovirt/devices/rng.rs
+++ b/vmm/sandbox/src/stratovirt/devices/rng.rs
@@ -79,13 +79,14 @@ mod tests {
         let mut virtio_rng_device =
             VirtioRngDevice::new("rng0", "/dev/urandom", Transport::Pci, DEFAULT_PCIE_BUS);
         virtio_rng_device.set_device_addr(VIRTIO_RND_DEVICE_ADDR);
-        let virtio_rng_device_cmd_params = virtio_rng_device.to_cmdline_params("-");
+        let mut virtio_rng_device_cmd_params = virtio_rng_device.to_cmdline_params("-");
+        virtio_rng_device_cmd_params.sort();
         println!(
             "virtio-rng device params: {:?}",
             virtio_rng_device_cmd_params
         );
 
-        let expected_params: Vec<String> = vec![
+        let mut expected_params: Vec<String> = vec![
             "-object",
             "rng-random,id=rng0,filename=/dev/urandom",
             "-device",
@@ -94,6 +95,8 @@ mod tests {
         .iter()
         .map(|s| s.to_string())
         .collect();
-        assert!(true);
+        expected_params.sort();
+
+        assert_eq!(expected_params, virtio_rng_device_cmd_params);
     }
 }

--- a/vmm/sandbox/src/utils.rs
+++ b/vmm/sandbox/src/utils.rs
@@ -391,7 +391,7 @@ pub fn vec_to_string<T: ToString>(v: &[T]) -> String {
         .join(":")
 }
 
-pub fn fds_to_vectors<T>(fds: &Vec<T>) -> String {
+pub fn fds_to_vectors<T>(fds: &[T]) -> String {
     (2 * fds.len() + 2).to_string()
 }
 


### PR DESCRIPTION
fix #115

reason: The result of the cargo test command includes some compilation warnings that need to be cleaned.