### PR TITLE
sandbox: Ignore not found error in sandbox deletion

### DIFF
--- a/vmm/common/src/lib.rs
+++ b/vmm/common/src/lib.rs
@@ -35,7 +35,7 @@ pub const HOSTNAME_FILENAME: &str = "hostname";
 pub const RESOLV_FILENAME: &str = "resolv.conf";
 
 pub const SANDBOX_NS_PATH: &str = "/run/sandbox-ns";
-pub const NET_NAMESPACE: &str = "net";
+pub const NET_NAMESPACE: &str = "network";
 pub const IPC_NAMESPACE: &str = "ipc";
 pub const UTS_NAMESPACE: &str = "uts";
 pub const CGROUP_NAMESPACE: &str = "cgroup";

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -323,7 +323,12 @@ where
             }
 
             cleanup_mounts(&sb.base_dir).await?;
-            remove_dir_all(&sb.base_dir).await?;
+            // Should Ignore the NotFound error of base dir as it may be already deleted.
+            if let Err(e) = remove_dir_all(&sb.base_dir).await {
+                if e.kind() != ErrorKind::NotFound {
+                    return Err(e.into());
+                }
+            }
         }
         self.sandboxes.write().await.remove(id);
         Ok(())

--- a/vmm/task/src/main.rs
+++ b/vmm/task/src/main.rs
@@ -40,8 +40,7 @@ use signal_hook_tokio::Signals;
 use tokio::fs::File;
 use vmm_common::{
     api::sandbox_ttrpc::create_sandbox_service, mount::mount, ETC_RESOLV, HOSTNAME_FILENAME,
-    IPC_NAMESPACE, KUASAR_STATE_DIR, NET_NAMESPACE, RESOLV_FILENAME, SANDBOX_NS_PATH,
-    UTS_NAMESPACE,
+    IPC_NAMESPACE, KUASAR_STATE_DIR, RESOLV_FILENAME, SANDBOX_NS_PATH, UTS_NAMESPACE,
 };
 
 use crate::{
@@ -131,7 +130,6 @@ lazy_static! {
         options: vec!["relatime", "nodev", "sync", "dirsync",]
     },];
     static ref CLONE_FLAG_TABLE: HashMap<String, CloneFlags> = HashMap::from([
-        (String::from(NET_NAMESPACE), CloneFlags::CLONE_NEWNET),
         (String::from(IPC_NAMESPACE), CloneFlags::CLONE_NEWIPC),
         (String::from(UTS_NAMESPACE), CloneFlags::CLONE_NEWUTS),
     ]);


### PR DESCRIPTION
Since the sandbox was deleted more than twice, the sandbox dir should already be removed in the first time. Thus, should ignore not found error in the following delation.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>