### PR TITLE
network: fix private sandbox netns

### DIFF
--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -187,7 +187,7 @@ impl VM for CloudHypervisorVM {
 
         // update vmm related pids
         self.pids.vmm_pid = pid;
-        self.pids.affilicated_pids.push(virtiofsd_pid);
+        self.pids.affiliated_pids.push(virtiofsd_pid);
         // TODO: add child virtiofsd process
         Ok(pid.unwrap_or_default())
     }

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -271,7 +271,7 @@ where
                     .sandbox_cgroups
                     .add_process_into_sandbox_cgroups(vmm_pid, Some(vcpu_threads))?;
                 // move all vmm-related process into sandbox cgroup
-                for pid in sandbox.vm.pids().affilicated_pids {
+                for pid in sandbox.vm.pids().affiliated_pids {
                     sandbox
                         .sandbox_cgroups
                         .add_process_into_sandbox_cgroups(pid, None)?;

--- a/vmm/sandbox/src/stratovirt/mod.rs
+++ b/vmm/sandbox/src/stratovirt/mod.rs
@@ -149,7 +149,7 @@ impl VM for StratoVirtVM {
         self.pids.vmm_pid = Some(vmm_pid);
         if let Some(virtiofsd) = &self.virtiofs_daemon {
             if let Some(pid) = virtiofsd.pid {
-                self.pids.affilicated_pids.push(pid);
+                self.pids.affiliated_pids.push(pid);
             }
         }
 

--- a/vmm/sandbox/src/vm.rs
+++ b/vmm/sandbox/src/vm.rs
@@ -210,5 +210,5 @@ pub struct VcpuThreads {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Pids {
     pub vmm_pid: Option<u32>,
-    pub affilicated_pids: Vec<u32>,
+    pub affiliated_pids: Vec<u32>,
 }


### PR DESCRIPTION
Optimize sandbox lifecycle management

1. Add many roll back handlers in the process of starting sandbox.
2. Move setup network to Start sandbox as it should be called near the vm startup.
3. Only monit running sandbox and dump it status in time.
4. Sandbox stop should make sure the sandbox is stopped successfully, so wait it
to stop for 10s.
5. If the VM process terminated suddenly and the containerd has no idea to stop
sandbox, destroy network should be done in monit thread.
6. Forcefully kill vmm process in stopping sandbox.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>