### PR TITLE
build: add some commands and make build.sh independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ bin/vmlinux.bin:
 	@mkdir -p bin && cp vmm/scripts/kernel/${HYPERVISOR}/vmlinux.bin bin/vmlinux.bin && rm vmm/scripts/kernel/${HYPERVISOR}/vmlinux.bin
 
 bin/kuasar.img:
-	@bash vmm/scripts/image/${GUESTOS_IMAGE}/build.sh image
+	@bash vmm/scripts/image/build.sh image ${GUESTOS_IMAGE}
 	@mkdir -p bin && cp /tmp/kuasar.img bin/kuasar.img && rm /tmp/kuasar.img
 
 bin/kuasar.initrd:
-	@bash vmm/scripts/image/${GUESTOS_IMAGE}/build.sh initrd
+	@bash vmm/scripts/image/build.sh initrd ${GUESTOS_IMAGE}
 	@mkdir -p bin && cp /tmp/kuasar.initrd bin/kuasar.initrd && rm /tmp/kuasar.initrd
 
 bin/wasm-sandboxer:

--- a/vmm/scripts/image/build.sh
+++ b/vmm/scripts/image/build.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 exit_flag=0
+export GUESTOS_IMAGE=${2:-"centos"}
 export IMAGE_NAME=${IMAGE_NAME:-"centos:7"}
 export ROOTFS_DIR=${ROOTFS_DIR:-"/tmp/kuasar-rootfs"}
 export CONTAINER_RUNTIME=${RUNTIME:-"containerd"}
@@ -40,7 +41,7 @@ echo "build in ${IMAGE_NAME}"
 
 if [ ! -n "${REPO_DIR}" ]; then
 	current_dir=$(dirname "$(readlink -f "$0")")
-	pushd ${current_dir}/../../../..
+	pushd ${current_dir}/../../..
 	REPO_DIR=$(pwd)
 	popd
 fi
@@ -68,7 +69,7 @@ containerd)
 		--mount type=bind,src="${ROOTFS_DIR}",dst=/tmp/kuasar-rootfs,options=rbind:rw \
 		${IMAGE_NAME} \
 		${container_name} \
-		bash /kuasar/vmm/scripts/image/centos/build_rootfs.sh
+		bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
 	fn_check_result $? "ctr run ${container_name} return error!"
 	;;
 docker)
@@ -80,7 +81,7 @@ docker)
 		-v "${REPO_DIR}":/kuasar \
 		-v "${ROOTFS_DIR}":"/tmp/kuasar-rootfs" \
 		${IMAGE_NAME} \
-		bash /kuasar/vmm/scripts/image/centos/build_rootfs.sh
+		bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
 	fn_check_result $? "docker run ${container_name} return error!"
 	;;
 isulad)
@@ -93,7 +94,7 @@ isulad)
 		-v "${REPO_DIR}":/kuasar \
 		-v "${ROOTFS_DIR}":"/tmp/kuasar-rootfs" \
 		${IMAGE_NAME} \
-		bash /kuasar/vmm/scripts/image/centos/build_rootfs.sh
+		bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
 	fn_check_result $? "isula run ${container_name} return error!"
 	;;
 *)

--- a/vmm/scripts/image/centos/binaries.list
+++ b/vmm/scripts/image/centos/binaries.list
@@ -7,6 +7,9 @@
 /usr/bin/sh /bin
 # procps-ng
 /usr/bin/ps /bin
+/usr/bin/kill /bin
+/usr/bin/free /bin
+/usr/bin/top /bin
 # kmod
 /usr/sbin/modprobe /sbin
 /usr/sbin/depmod /sbin
@@ -23,6 +26,7 @@
 /usr/bin/quotasync /bin
 # cni
 /usr/sbin/arping /sbin
+/usr/bin/ping /sbin
 /usr/bin/echo /bin
 # iptables
 /usr/sbin/iptables /sbin
@@ -32,3 +36,18 @@
 /usr/bin/ls /bin
 /usr/bin/cat /bin
 /usr/bin/cp /bin
+/usr/bin/mv /bin
+/usr/bin/rm /bin
+/usr/bin/mkdir /bin
+/usr/bin/find /bin
+/usr/bin/awk /bin
+/usr/bin/grep /bin
+/usr/bin/chmod /bin
+/usr/bin/chown /bin
+/usr/bin/dmesg /bin
+/usr/bin/ln /bin
+/usr/bin/curl /bin
+/usr/sbin/ethtool /sbin
+/usr/bin/netstat /bin
+/usr/sbin/ip /sbin
+# End of file, do not delete

--- a/vmm/scripts/image/centos/build_rootfs.sh
+++ b/vmm/scripts/image/centos/build_rootfs.sh
@@ -114,18 +114,19 @@ install_and_copy_rpm() {
                 yum install -y $rpm >/dev/null 2>&1
                 if [ $? -ne 0 ]; then
                     echo "Can not install $rpm by yum"
-                    exit 1
+                    continue
                 fi
+                rpm -ql $rpm >/dev/null 2>&1 || continue
             fi
             array=($(rpm -ql $rpm | grep -v "share" | grep -v ".build-id"))
             for file in ${array[@]}; do
                 source=$file
-                dts_file=${rootfs_dir}$file
-                dts_folder=${dts_file%/*}
-                if [ ! -d "$dts_folder" ]; then
-                    mkdir -p $dts_folder
+                dst_file=${rootfs_dir}$file
+                dst_folder=${dst_file%/*}
+                if [ ! -d "$dst_folder" ] && [ ! -L "$dst_folder" ]; then
+                    mkdir -p $dst_folder
                 fi
-                cp -r -f -d $source $dts_folder
+                cp -r -f -d $source $dst_folder
             done
         fi
     done

--- a/vmm/scripts/image/centos/rpm.list
+++ b/vmm/scripts/image/centos/rpm.list
@@ -20,3 +20,8 @@ libpcap
 iptables
 ipvsadm
 conntrack-tools
+curl
+ethtool
+net-tools
+iproute
+# End of file, do not delete


### PR DESCRIPTION
1. add some command binaries for debug in vm
2. build.sh is for docker/ctr/isula to prepare guest rootfs and build it to image or initrd, thus it should not have any difference with each guest os.