### PR TITLE
refactor: refactor flag parser

### DIFF
--- a/vmm/sandbox/Cargo.lock
+++ b/vmm/sandbox/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 [[package]]
 name = "containerd-sandbox"
 version = "0.1.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#a0fac88f1594ae9694d4cec65b21c57108915c70"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim"
 version = "0.3.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#a0fac88f1594ae9694d4cec65b21c57108915c70"
 dependencies = [
  "async-trait",
  "cgroups-rs 0.2.11",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim-protos"
 version = "0.2.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#a0fac88f1594ae9694d4cec65b21c57108915c70"
 dependencies = [
  "async-trait",
  "protobuf 3.2.0",
@@ -1561,7 +1561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.20.0",
+ "nix 0.26.2",
 ]
 
 [[package]]

--- a/vmm/sandbox/src/args.rs
+++ b/vmm/sandbox/src/args.rs
@@ -22,15 +22,48 @@ pub struct Args {
     #[arg(short, long)]
     pub version: bool,
 
-    /// Config file path, only for cloud hypervisor and stratovirt
-    #[arg(short, long, value_name = "FILE")]
-    pub config: Option<String>,
+    /// Config file path, only for cloud hypervisor and stratovirt, default is `/var/lib/kuasar/config_clh.toml`
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        default_value = "/var/lib/kuasar/config_clh.toml"
+    )]
+    pub config: String,
 
-    /// Sandboxer working directory
-    #[arg(short, long, value_name = "DIR")]
-    pub dir: Option<String>,
+    /// Sandboxer working directory, default is `/run/kuasar-vmm`
+    #[arg(short, long, value_name = "DIR", default_value = "/run/kuasar-vmm")]
+    pub dir: String,
 
-    /// Address for sandboxer's server
-    #[arg(short, long, value_name = "FILE")]
-    pub listen: Option<String>,
+    /// Address for sandboxer's server, default is `/run/vmm-sandboxer.sock`
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        default_value = "/run/vmm-sandboxer.sock"
+    )]
+    pub listen: String,
+
+    // log_level is optional and should not have default value if not given, since
+    // it can be defined in configuration file.
+    /// Logging level for sandboxer [trace, debug, info, warn, error, fatal, panic]
+    #[arg(long, value_name = "STRING")]
+    pub log_level: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::args::Args;
+
+    #[test]
+    fn test_args_parse_default() {
+        let args = Args::parse();
+        assert!(!args.version);
+        assert_eq!(args.config, "/var/lib/kuasar/config_clh.toml");
+        assert_eq!(args.dir, "/run/kuasar-vmm");
+        assert_eq!(args.listen, "/run/vmm-sandboxer.sock");
+        assert!(args.log_level.is_none());
+    }
 }

--- a/vmm/sandbox/src/bin/qemu/main.rs
+++ b/vmm/sandbox/src/bin/qemu/main.rs
@@ -15,26 +15,58 @@ limitations under the License.
 */
 
 use clap::Parser;
-use vmm_sandboxer::{args, qemu::init_qemu_sandboxer, utils::init_logger, version};
+use vmm_sandboxer::{
+    args,
+    config::Config,
+    kata_config::KataConfig,
+    qemu::{factory::QemuVMFactory, hooks::QemuHooks},
+    sandbox::KuasarSandboxer,
+    utils::init_logger,
+    version,
+};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
     let args = args::Args::parse();
     if args.version {
         version::print_version_info();
-        return Ok(());
+        return;
     }
 
-    // Initialize sandboxer
-    let sandboxer = init_qemu_sandboxer(&args).await?;
+    // For compatibility with kata config
+    let config_path = std::env::var("KATA_CONFIG_PATH")
+        .unwrap_or_else(|_| "/usr/share/defaults/kata-containers/configuration.toml".to_string());
+    let path = std::path::Path::new(&config_path);
+
+    let config = if path.exists() {
+        KataConfig::init(path).await.unwrap();
+        let sandbox_config = KataConfig::sandbox_config("qemu").await.unwrap();
+        let vmm_config = KataConfig::hypervisor_config("qemu", |h| h.clone())
+            .await
+            .unwrap()
+            .to_qemu_config()
+            .unwrap();
+        Config::new(sandbox_config, vmm_config)
+    } else {
+        Config::load_config(&args.config).await.unwrap()
+    };
 
     // Initialize log
-    init_logger(sandboxer.log_level());
+    init_logger(&config.sandbox.log_level());
+
+    let sandboxer: KuasarSandboxer<QemuVMFactory, QemuHooks> = KuasarSandboxer::new(
+        config.sandbox,
+        config.hypervisor.clone(),
+        QemuHooks::new(config.hypervisor),
+    );
 
     // Run the sandboxer
-    containerd_sandbox::run("kuasar-sandboxer", sandboxer)
-        .await
-        .unwrap();
-
-    Ok(())
+    containerd_sandbox::run(
+        "kuasar-vmm-sandboxer-qemu",
+        &args.listen,
+        &args.dir,
+        sandboxer,
+    )
+    .await
+    .unwrap();
 }

--- a/vmm/sandbox/src/cloud_hypervisor/hooks.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/hooks.rs
@@ -20,6 +20,7 @@ use crate::{
     cloud_hypervisor::CloudHypervisorVM, sandbox::KuasarSandbox, utils::get_resources, vm::Hooks,
 };
 
+#[derive(Default)]
 pub struct CloudHypervisorHooks {}
 
 #[async_trait::async_trait]

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -31,9 +31,7 @@ use tokio::{
 };
 use vmm_common::SHARED_DIR_SUFFIX;
 
-use self::{factory::CloudHypervisorVMFactory, hooks::CloudHypervisorHooks};
 use crate::{
-    args::Args,
     cloud_hypervisor::{
         client::ChClient,
         config::{CloudHypervisorConfig, CloudHypervisorVMConfig, VirtiofsdConfig},
@@ -42,9 +40,7 @@ use crate::{
         },
     },
     device::{BusType, DeviceInfo},
-    load_config,
     param::ToCmdLineParams,
-    sandbox::KuasarSandboxer,
     utils::{read_std, set_cmd_fd, set_cmd_netns, wait_channel, wait_pid, write_file_atomic},
     vm::{Pids, VcpuThreads, VM},
 };
@@ -56,7 +52,6 @@ pub mod factory;
 pub mod hooks;
 
 const VCPU_PREFIX: &str = "vcpu";
-pub const CONFIG_CLH_PATH: &str = "/var/lib/kuasar/config_clh.toml";
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct CloudHypervisorVM {
@@ -398,17 +393,4 @@ fn spawn_wait(
             }
         }
     })
-}
-
-pub async fn init_cloud_hypervisor_sandboxer(
-    args: &Args,
-) -> Result<KuasarSandboxer<CloudHypervisorVMFactory, CloudHypervisorHooks>> {
-    let (config, persist_dir_path) =
-        load_config::<CloudHypervisorVMConfig>(args, CONFIG_CLH_PATH).await?;
-    let hooks = CloudHypervisorHooks {};
-    let mut s = KuasarSandboxer::new(config.sandbox, config.hypervisor, hooks);
-    if !persist_dir_path.is_empty() {
-        s.recover(&persist_dir_path).await?;
-    }
-    Ok(s)
 }

--- a/vmm/sandbox/src/config.rs
+++ b/vmm/sandbox/src/config.rs
@@ -14,10 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::path::Path;
-
 use anyhow::anyhow;
-use containerd_sandbox::error;
+use containerd_sandbox::error::Result;
 use serde::de::DeserializeOwned;
 use serde_derive::Deserialize;
 use tokio::fs::read_to_string;
@@ -31,10 +29,104 @@ pub struct Config<T> {
 }
 
 impl<T: DeserializeOwned> Config<T> {
-    pub async fn parse<P: AsRef<Path>>(path: P) -> error::Result<Self> {
-        let toml_str = read_to_string(&path).await?;
-        let conf: Self = toml::from_str(&toml_str)
-            .map_err(|e| anyhow!("failed to parse kuasar sandboxer config {}", e))?;
-        Ok(conf)
+    pub fn new(sandbox: SandboxConfig, hypervisor: T) -> Self {
+        Self {
+            sandbox,
+            hypervisor,
+        }
+    }
+
+    // Load config from configuration file, args in command line will override args in file
+    pub async fn load_config(config_path: &str) -> Result<Self> {
+        if config_path.is_empty() {
+            return Err(anyhow!("config path is empty").into());
+        }
+        // Parse config from toml file
+        let toml_str = read_to_string(config_path).await?;
+
+        let config = toml::from_str(&toml_str)
+            .map_err(|e| anyhow!("failed to parse kuasar sandboxer config: {}", e))?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::path::Path;
+
+    use containerd_sandbox::error::Result;
+    use containerd_shim::util::write_str_to_file;
+    use serde_derive::Deserialize;
+    use temp_dir::TempDir;
+
+    use crate::{config::Config, sandbox::SandboxConfig};
+
+    #[derive(Deserialize)]
+    struct MockHypervisor {
+        path: String,
+    }
+
+    #[test]
+    fn test_config_new() {
+        let mut sandbox_config = SandboxConfig::default();
+        sandbox_config.log_level = "debug".to_string();
+        let mock_path = "/usr/local/bin/mock-hypervisor";
+        let mock_config = MockHypervisor {
+            path: mock_path.to_string(),
+        };
+        let config = Config::new(sandbox_config, mock_config);
+
+        assert_eq!(config.sandbox.log_level, "debug");
+        assert_eq!(config.hypervisor.path, mock_path);
+    }
+
+    #[tokio::test]
+    async fn test_config_load_empty_dir() {
+        let res: Result<Config<MockHypervisor>> = Config::load_config("").await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_config_load() {
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_path = Path::join(tmp_dir.path(), "config_clh.toml");
+
+        let toml_str = "
+[sandbox]
+log_level = \"debug\"
+[hypervisor]
+path = \"/usr/local/bin/mock-hypervisor\"
+";
+        write_str_to_file(tmp_path.as_path(), toml_str)
+            .await
+            .unwrap();
+
+        let config: Config<MockHypervisor> = Config::load_config(tmp_path.to_str().unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(config.sandbox.log_level, "debug");
+        assert_eq!(config.hypervisor.path, "/usr/local/bin/mock-hypervisor");
+    }
+
+    #[tokio::test]
+    async fn test_config_load_with_wrong_config() {
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_path = Path::join(tmp_dir.path(), "config_clh.toml");
+
+        let toml_str = "
+[sandbox]
+log_level = \"\"
+[hypervisor]
+no_key = 0
+";
+        write_str_to_file(tmp_path.as_path(), toml_str)
+            .await
+            .unwrap();
+
+        let res: Result<Config<MockHypervisor>> =
+            Config::load_config(tmp_path.to_str().unwrap()).await;
+
+        assert!(res.is_err())
     }
 }

--- a/vmm/sandbox/src/container/handler/append.rs
+++ b/vmm/sandbox/src/container/handler/append.rs
@@ -20,8 +20,8 @@ use containerd_sandbox::{error::Result, ContainerOption};
 
 use crate::{
     container::{handler::Handler, KuasarContainer},
+    sandbox::KuasarSandbox,
     vm::VM,
-    KuasarSandbox,
 };
 
 pub struct MetadataAddHandler {

--- a/vmm/sandbox/src/container/handler/mod.rs
+++ b/vmm/sandbox/src/container/handler/mod.rs
@@ -30,8 +30,8 @@ use crate::{
         spec::SpecHandler,
         storage::StorageHandler,
     },
+    sandbox::KuasarSandbox,
     vm::VM,
-    KuasarSandbox,
 };
 
 pub mod append;

--- a/vmm/sandbox/src/container/handler/mount.rs
+++ b/vmm/sandbox/src/container/handler/mount.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use async_trait::async_trait;
 use containerd_sandbox::{error::Result, spec::Mount};
 
-use crate::{container::handler::Handler, vm::VM, KuasarSandbox};
+use crate::{container::handler::Handler, sandbox::KuasarSandbox, vm::VM};
 
 pub struct MountHandler {
     mount: Mount,

--- a/vmm/sandbox/src/lib.rs
+++ b/vmm/sandbox/src/lib.rs
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use anyhow::Context;
-use serde::de::DeserializeOwned;
-
-use crate::{args::Args, config::Config, sandbox::KuasarSandbox};
-
 #[macro_use]
 mod device;
 
@@ -40,30 +35,3 @@ pub mod sandbox;
 pub mod stratovirt;
 pub mod utils;
 pub mod version;
-
-async fn load_config<T: DeserializeOwned>(
-    args: &Args,
-    default_config_path: &str,
-) -> anyhow::Result<(Config<T>, String)> {
-    let mut config_path = default_config_path.to_string();
-    let mut dir_path = String::new();
-    if let Some(c) = &args.config {
-        config_path = c.to_string();
-    }
-    if let Some(d) = &args.dir {
-        dir_path = d.to_string();
-        if !std::path::Path::new(&dir_path).exists() {
-            tokio::fs::create_dir_all(&dir_path)
-                .await
-                .with_context(|| format!("Failed to mkdir for {}", dir_path))?;
-        }
-    }
-
-    let path = std::path::Path::new(&config_path);
-    let config: Config<T> = if path.exists() {
-        Config::parse(path).await?
-    } else {
-        panic!("config file {} not exist", config_path);
-    };
-    Ok((config, dir_path))
-}

--- a/vmm/sandbox/src/qemu/config.rs
+++ b/vmm/sandbox/src/qemu/config.rs
@@ -66,7 +66,7 @@ lazy_static! {
     };
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct QemuVMConfig {
     pub common: HypervisorCommonConfig,
     pub machine_accelerators: String,

--- a/vmm/sandbox/src/qemu/mod.rs
+++ b/vmm/sandbox/src/qemu/mod.rs
@@ -40,12 +40,9 @@ use tokio::{
 };
 use unshare::Fd;
 
-use self::{factory::QemuVMFactory, hooks::QemuHooks};
 use crate::{
-    args::Args,
     device::{BusType, DeviceInfo, SlotStatus, Transport},
     impl_recoverable,
-    kata_config::KataConfig,
     param::ToCmdLineParams,
     qemu::{
         config::QemuConfig,
@@ -60,7 +57,6 @@ use crate::{
         qmp_client::QmpClient,
         utils::detect_pid,
     },
-    sandbox::KuasarSandboxer,
     utils::{read_std, wait_channel, wait_pid},
     vm::{BlockDriver, Pids, VcpuThreads, VM},
 };
@@ -532,29 +528,3 @@ impl QemuVM {
 }
 
 impl_recoverable!(QemuVM);
-
-pub async fn init_qemu_sandboxer(args: &Args) -> Result<KuasarSandboxer<QemuVMFactory, QemuHooks>> {
-    // For compatibility with kata config
-    let config_path = std::env::var("KATA_CONFIG_PATH")
-        .unwrap_or_else(|_| "/usr/share/defaults/kata-containers/configuration.toml".to_string());
-
-    let path = std::path::Path::new(&config_path);
-    if path.exists() {
-        KataConfig::init(path).await?;
-    }
-
-    let vmm_config = KataConfig::hypervisor_config("qemu", |h| h.clone()).await?;
-    let vmm_config = vmm_config.to_qemu_config()?;
-    let sandbox_config = KataConfig::sandbox_config("qemu").await?;
-    let hooks = QemuHooks::new(vmm_config.clone());
-    let mut s = KuasarSandboxer::new(sandbox_config, vmm_config, hooks);
-
-    // Check for "--dir" argument and recover from persisted directory
-    if let Some(persist_dir_path) = &args.dir {
-        if std::path::Path::new(&persist_dir_path).exists() {
-            s.recover(persist_dir_path).await?;
-        }
-    }
-
-    Ok(s)
-}

--- a/vmm/sandbox/src/storage/mod.rs
+++ b/vmm/sandbox/src/storage/mod.rs
@@ -33,10 +33,9 @@ use vmm_common::{
 
 use crate::{
     device::{BlockDeviceInfo, DeviceInfo},
-    sandbox::KUASAR_GUEST_SHARE_DIR,
+    sandbox::{KuasarSandbox, KUASAR_GUEST_SHARE_DIR},
     storage::mount::{get_mount_info, is_bind, is_bind_shm, is_overlay},
     vm::{BlockDriver, VM},
-    KuasarSandbox,
 };
 
 pub mod mount;

--- a/vmm/sandbox/src/stratovirt/mod.rs
+++ b/vmm/sandbox/src/stratovirt/mod.rs
@@ -41,18 +41,11 @@ use tokio::{
 };
 use unshare::Fd;
 
-use self::{
-    config::StratoVirtVMConfig,
-    devices::{pcie_rootbus::PcieRootBus, rootport::RootPort, PCIE_ROOTBUS_CAPACITY},
-    factory::StratoVirtVMFactory,
-    hooks::StratoVirtHooks,
-};
+use self::devices::{pcie_rootbus::PcieRootBus, rootport::RootPort, PCIE_ROOTBUS_CAPACITY};
 use crate::{
-    args::Args,
     device::{Bus, BusType, DeviceInfo, Slot, SlotStatus},
-    impl_recoverable, load_config,
+    impl_recoverable,
     param::ToCmdLineParams,
-    sandbox::KuasarSandboxer,
     stratovirt::{
         config::StratoVirtConfig,
         devices::{
@@ -554,16 +547,3 @@ impl StratoVirtVM {
 }
 
 impl_recoverable!(StratoVirtVM);
-
-pub async fn init_stratovirt_sandboxer(
-    args: &Args,
-) -> Result<KuasarSandboxer<StratoVirtVMFactory, StratoVirtHooks>> {
-    let (config, persist_dir_path) =
-        load_config::<StratoVirtVMConfig>(args, CONFIG_STRATOVIRT_PATH).await?;
-    let hooks = StratoVirtHooks::new(config.hypervisor.clone());
-    let mut s = KuasarSandboxer::new(config.sandbox, config.hypervisor, hooks);
-    if !persist_dir_path.is_empty() {
-        s.recover(&persist_dir_path).await?;
-    }
-    Ok(s)
-}

--- a/vmm/sandbox/src/vm.rs
+++ b/vmm/sandbox/src/vm.rs
@@ -134,7 +134,7 @@ impl Default for HypervisorCommonConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 #[allow(clippy::enum_variant_names)]
 pub enum BlockDriver {
     VirtioBlk,
@@ -184,7 +184,7 @@ impl BlockDriver {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub enum ShareFsType {
     Virtio9P,
     VirtioFS,


### PR DESCRIPTION
Follow up: https://github.com/kuasar-io/rust-extensions/pull/30
The origional flags were parsed by both vmm-sandboxer and containerd-sandbox, which is arguly. I refactor this logic, paas the `listening_addr` and `working_dir` to run a sandboxer instance.

Considering practical uses, I al;so add a new flag `log_levl` in commandline for debuging.