### PR TITLE
vmm: fix tmpfs bind dir empty

### DIFF
--- a/vmm/sandbox/src/storage/mod.rs
+++ b/vmm/sandbox/src/storage/mod.rs
@@ -64,7 +64,8 @@ where
         // handle tmpfs mount
         let mount_info = get_mount_info(&m.source).await?;
         if let Some(mi) = mount_info {
-            if mi.fs_type == "tmpfs" {
+            // Only allow use tmpfs in emptyDir
+            if mi.fs_type == "tmpfs" && mi.mount_point.contains("kubernetes.io~empty-dir") {
                 self.handle_tmpfs_mount(&id, container_id, m, &mi).await?;
                 return Ok(());
             }
@@ -317,6 +318,7 @@ where
 }
 
 pub struct MountInfo {
+    pub mount_point: String,
     pub fs_type: String,
     pub options: Vec<String>,
 }

--- a/vmm/sandbox/src/storage/mount.rs
+++ b/vmm/sandbox/src/storage/mount.rs
@@ -47,7 +47,11 @@ pub async fn get_mount_info(mount_point: &str) -> Result<Option<MountInfo>> {
         if mp == mount_point {
             let fs_type = fields[2].to_string();
             let options = fields[3].split(',').map(|x| x.to_string()).collect();
-            return Ok(Some(MountInfo { fs_type, options }));
+            return Ok(Some(MountInfo {
+                mount_point: mp,
+                fs_type,
+                options,
+            }));
         }
     }
     Ok(None)


### PR DESCRIPTION
When the mounted hostpath is tmpfs or when mounting a secret, the container cannot access the data. These two types of mounts are tmpfs, and due to memory isolation between the host and the virtual machine, the virtual machine will reallocate tmpfs, resulting in empty data. 

Fix:Except for empty dir allocated by memory, all other tmpfs are bind-mounted into the virtual machine.