### PR TITLE
building: update guest image to fedora:40

### DIFF
--- a/vmm/scripts/image/build.sh
+++ b/vmm/scripts/image/build.sh
@@ -15,7 +15,7 @@
 
 exit_flag=0
 export GUESTOS_IMAGE=${2:-"centos"}
-export IMAGE_NAME=${IMAGE_NAME:-"centos:7"}
+export IMAGE_NAME=${IMAGE_NAME:-"registry.fedoraproject.org/fedora:40"}
 export ROOTFS_DIR=${ROOTFS_DIR:-"/tmp/kuasar-rootfs"}
 export CONTAINER_RUNTIME=${RUNTIME:-"containerd"}
 CONTAINERD_NS=${CONTAINERD_NS:-"default"}

--- a/vmm/scripts/image/centos/binaries.list
+++ b/vmm/scripts/image/centos/binaries.list
@@ -25,13 +25,13 @@
 /usr/bin/quota* /bin
 /usr/bin/quotasync /bin
 # cni
-/usr/sbin/arping /sbin
+/usr/bin/arping /sbin
 /usr/bin/ping /sbin
 /usr/bin/echo /bin
 # iptables
-/usr/sbin/iptables /sbin
-/usr/sbin/iptables-restore /sbin
-/usr/sbin/iptables-save /sbin
+/etc/alternatives/iptables /etc/alternatives
+/etc/alternatives/iptables-restore /etc/alternatives
+/etc/alternatives/iptables-save /etc/alternatives
 # debug
 /usr/bin/ls /bin
 /usr/bin/cat /bin
@@ -40,7 +40,6 @@
 /usr/bin/rm /bin
 /usr/bin/mkdir /bin
 /usr/bin/find /bin
-/usr/bin/awk /bin
 /usr/bin/grep /bin
 /usr/bin/chmod /bin
 /usr/bin/chown /bin
@@ -50,4 +49,6 @@
 /usr/sbin/ethtool /sbin
 /usr/bin/netstat /bin
 /usr/sbin/ip /sbin
+/usr/sbin/busybox /bin
+/usr/bin/ldd /bin
 # End of file, do not delete

--- a/vmm/scripts/image/centos/build_rootfs.sh
+++ b/vmm/scripts/image/centos/build_rootfs.sh
@@ -24,21 +24,7 @@ ARCH=$(uname -m)
 make_vmm_task() {
     local repo_dir="$1"
 
-    # install cmake3 because some rust modules depends on it
-    # centos 7 install cmake 2.8 by default, has to add epel repo to install cmake3
-    . /etc/os-release
-    if [ ${VERSION_ID} -le 7 ]; then
-        yum install -y epel-release
-        yum install -y cmake3 make gcc gcc-c++ wget
-        rm -f /usr/bin/cmake
-        ln -s /usr/bin/cmake3 /usr/bin/cmake
-    else
-        # CentOS Linux 8 had reached the End Of Life (EOL) on December 31st, 2021. It means that CentOS 8 will no longer receive development resources from the official CentOS project. After Dec 31st, 2021, if you need to update your CentOS, you need to change the mirrors to vault.centos.org where they will be archived permanently. Alternatively, you may want to upgrade to CentOS Stream.
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        yum clean all
-        yum install cmake make gcc-c++ wget
-    fi
+    yum install -y cmake make gcc-c++ wget
 
     # update cert file under internal proxy scenario
     if [ -f "${cert_file_path}" ]; then

--- a/vmm/scripts/image/centos/rpm.list
+++ b/vmm/scripts/image/centos/rpm.list
@@ -1,7 +1,6 @@
 nfs-utils
 tcp_wrappers-libs
 rpcbind
-libverto-tevent
 libtirpc
 libtevent
 libtalloc
@@ -17,6 +16,7 @@ keyutils
 gssproxy
 e2fsprogs-libs
 libpcap
+iptables-libs
 iptables
 ipvsadm
 conntrack-tools
@@ -24,4 +24,8 @@ curl
 ethtool
 net-tools
 iproute
+busybox
+psmisc
+procps-ng
+iputils
 # End of file, do not delete


### PR DESCRIPTION
Update guest image to fedora:40 since CentOS7 was already EOS on July 2024.