### PR TITLE
build(deps): bump nix from 0.25.0 to 0.28.0 in /vmm/task

### DIFF
--- a/vmm/task/Cargo.lock
+++ b/vmm/task/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes 1.4.0",
  "futures-util",
  "http",
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "cgroups-rs"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,7 +243,7 @@ dependencies = [
 [[package]]
 name = "containerd-sandbox"
 version = "0.1.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#b9ad8e197385b72ada6c1b8482c155606d26c803"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -259,7 +271,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim"
 version = "0.3.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#b9ad8e197385b72ada6c1b8482c155606d26c803"
 dependencies = [
  "async-trait",
  "cgroups-rs",
@@ -270,7 +282,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.25.1",
+ "nix 0.28.0",
  "oci-spec",
  "page_size",
  "pin-project-lite",
@@ -290,7 +302,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim-protos"
 version = "0.2.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#b9ad8e197385b72ada6c1b8482c155606d26c803"
 dependencies = [
  "async-trait",
  "protobuf 3.2.0",
@@ -925,6 +937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea993e32c77d87f01236c38f572ecb6c311d592e56a06262a007fd2a6e31253c"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "libc",
  "netlink-packet-core",
@@ -1040,7 +1061,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -1053,7 +1074,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -1066,7 +1087,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
@@ -1079,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
@@ -1092,12 +1113,25 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1548,7 +1582,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1589,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "runc"
 version = "0.2.0"
-source = "git+https://github.com/kuasar-io/rust-extensions.git#5f2edcffe9dc4fe41f1f4d9a14843456d0a835ee"
+source = "git+https://github.com/kuasar-io/rust-extensions.git#b9ad8e197385b72ada6c1b8482c155606d26c803"
 dependencies = [
  "async-trait",
  "futures",
@@ -1622,7 +1656,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1982,7 +2016,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes 1.4.0",
  "futures-core",
  "futures-util",
@@ -2163,7 +2197,7 @@ dependencies = [
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys 0.7.0",
- "nix 0.25.1",
+ "nix 0.28.0",
  "oci-spec",
  "pin-project-lite",
  "rtnetlink",

--- a/vmm/task/Cargo.toml
+++ b/vmm/task/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 panic = 'abort'
 
 [dependencies]
-vmm-common = {path = "../common"}
+vmm-common = { path = "../common" }
 log = "0.4"
-nix = "0.25"
+nix = { version = "0.28.0", features = ["sched", "term", "time", "hostname", "signal", "mount", "uio", "socket"] }
 libc = "0.2.95"
 time = { version = "=0.3.7", features = ["serde", "std"] }
 serde = { version = "1.0.133", features = ["derive"] }
@@ -19,7 +19,7 @@ oci-spec = "0.5.4"
 crossbeam = "0.8.1"
 env_logger = "0.9.0"
 lazy_static = "1.4.0"
-netlink-sys = { version = "0.7.0", features = ["tokio_socket"]}
+netlink-sys = { version = "0.7.0", features = ["tokio_socket"] }
 rtnetlink = "0.12"
 netlink-packet-route = "0.15"
 netlink-packet-core = "0.5.0"
@@ -27,13 +27,13 @@ ipnetwork = "0.20"
 anyhow = { version = "1.0.66", default-features = false, features = ["std", "backtrace"] }
 
 # Async dependencies
-async-trait = { version = "0.1.51"}
-tokio = { version = "1.17.0", features = ["full"]}
-futures = { version = "0.3.21"}
-signal-hook-tokio = {version = "0.3.1", features = ["futures-v0_3"]}
+async-trait = { version = "0.1.51" }
+tokio = { version = "1.17.0", features = ["full"] }
+futures = { version = "0.3.21" }
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio-vsock = "0.3.1"
 pin-project-lite = "0.2.7"
 ttrpc = { version = "0.7", features = ["async"] }
 
-containerd-shim = { git="https://github.com/kuasar-io/rust-extensions.git", features=["async"] }
-runc = { git="https://github.com/kuasar-io/rust-extensions.git", features=["async"] }
+containerd-shim = { git = "https://github.com/kuasar-io/rust-extensions.git", features = ["async"] }
+runc = { git = "https://github.com/kuasar-io/rust-extensions.git", features = ["async"] }

--- a/vmm/task/src/main.rs
+++ b/vmm/task/src/main.rs
@@ -140,7 +140,7 @@ lazy_static! {
     ]);
 }
 
-async fn initialize() -> anyhow::Result<()> {
+async fn start_task_server() -> anyhow::Result<()> {
     early_init_call().await?;
 
     let config = TaskConfig::new().await?;
@@ -172,26 +172,16 @@ async fn initialize() -> anyhow::Result<()> {
 
     late_init_call().await?;
 
+    start_ttrpc_server().await?.start().await?;
+
     Ok(())
 }
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = initialize().await {
-        error!("failed to do init call: {:?}", e);
-        exit(-1);
-    }
-
-    // Keep server alive in main function
-    let mut server = match create_ttrpc_server().await {
-        Ok(s) => s,
-        Err(e) => {
-            error!("failed to create ttrpc server: {:?}", e);
-            exit(-1);
-        }
-    };
-    if let Err(e) = server.start().await {
-        error!("failed to start ttrpc server: {:?}", e);
+    // start task server
+    if let Err(e) = start_task_server().await {
+        error!("failed to start task server: {:?}", e);
         exit(-1);
     }
 
@@ -362,9 +352,9 @@ async fn mount_static_mounts(mounts: Vec<StaticMount>) -> Result<()> {
     Ok(())
 }
 
-// create_ttrpc_server will create all the ttrpc service and register them to a server that
+// start_ttrpc_server will create all the ttrpc service and register them to a server that
 // bind to vsock 1024 port.
-async fn create_ttrpc_server() -> anyhow::Result<Server> {
+async fn start_ttrpc_server() -> anyhow::Result<Server> {
     let task = create_task_service().await?;
     let task_service = create_task(Arc::new(Box::new(task)));
 

--- a/vmm/task/src/netlink.rs
+++ b/vmm/task/src/netlink.rs
@@ -371,7 +371,7 @@ impl Handle {
                 }
 
                 if let Err(rtnetlink::Error::NetlinkError(message)) = request.execute().await {
-                    if Errno::from_i32(message.code.abs()) != Errno::EEXIST {
+                    if Errno::from_raw(message.code.abs()) != Errno::EEXIST {
                         return Err(other!(
                             "Failed to add IP v6 route (src: {}, dst: {}, gtw: {},Err: {})",
                             route.source,
@@ -418,7 +418,7 @@ impl Handle {
                 }
 
                 if let Err(rtnetlink::Error::NetlinkError(message)) = request.execute().await {
-                    if Errno::from_i32(message.code.abs()) != Errno::EEXIST {
+                    if Errno::from_raw(message.code.abs()) != Errno::EEXIST {
                         return Err(other!(
                             "Failed to add IP v4 route (src: {}, dst: {}, gtw: {},Err: {})",
                             route.source,


### PR DESCRIPTION
After https://github.com/kuasar-io/rust-extensions/pull/31, nix was bumped to 0.28.0 and should also bump it in vmm/task.