### PR TITLE
ci: use legacy 0.15.1 cargo-deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo clippy ${{ matrix.features }} -- -D warnings
       - name: Deny
         working-directory: ${{ matrix.directories }}
-        run: cargo install cargo-deny && cargo deny -L warn ${{ matrix.features }} check
+        run: cargo install cargo-deny@0.15.1 && cargo deny -L warn ${{ matrix.features }} check
 
   tests:
     strategy:


### PR DESCRIPTION
cargo-deny [0.16.0](https://github.com/EmbarkStudios/cargo-deny/releases) has changed a lot, use legacy 0.15.1 to check.