### PR TITLE
sandbox: support shared process namespace

### DIFF
--- a/vmm/common/src/lib.rs
+++ b/vmm/common/src/lib.rs
@@ -37,5 +37,6 @@ pub const RESOLV_FILENAME: &str = "resolv.conf";
 pub const SANDBOX_NS_PATH: &str = "/run/sandbox-ns";
 pub const NET_NAMESPACE: &str = "network";
 pub const IPC_NAMESPACE: &str = "ipc";
+pub const PID_NAMESPACE: &str = "pid";
 pub const UTS_NAMESPACE: &str = "uts";
 pub const CGROUP_NAMESPACE: &str = "cgroup";

--- a/vmm/sandbox/src/cloud_hypervisor/factory.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/factory.rs
@@ -22,6 +22,7 @@ use crate::{
         devices::{console::Console, fs::Fs, pmem::Pmem, rng::Rng, vsock::Vsock},
         CloudHypervisorVM,
     },
+    sandbox::has_shared_pid_namespace,
     utils::get_netns,
     vm::VMFactory,
 };
@@ -46,7 +47,9 @@ impl VMFactory for CloudHypervisorVMFactory {
     ) -> containerd_sandbox::error::Result<Self::VM> {
         let netns = get_netns(&s.sandbox);
         let mut vm = CloudHypervisorVM::new(id, &netns, &s.base_dir, &self.vm_config);
-
+        if has_shared_pid_namespace(&s.sandbox) {
+            vm.config.cmdline.push_str(" task.share_pidns")
+        }
         // add image as a disk
         if !self.vm_config.common.image_path.is_empty() {
             let rootfs_device = Pmem::new("rootfs", &self.vm_config.common.image_path, true);

--- a/vmm/task/src/config.rs
+++ b/vmm/task/src/config.rs
@@ -20,6 +20,7 @@ use tokio::fs::read_to_string;
 const SHAREFS_TYPE: &str = "task.sharefs_type";
 const LOG_LEVEL: &str = "task.log_level";
 const TASK_DEBUG: &str = "task.debug";
+const SHARE_PIDNS: &str = "task.share_pidns";
 
 macro_rules! parse_cmdline {
     ($param:ident, $key:ident, $field:expr) => {
@@ -41,6 +42,7 @@ macro_rules! parse_cmdline {
 pub struct TaskConfig {
     pub(crate) sharefs_type: String,
     pub(crate) log_level: String,
+    pub(crate) share_pidns: bool,
     pub(crate) debug: bool,
 }
 
@@ -49,6 +51,7 @@ impl Default for TaskConfig {
         TaskConfig {
             sharefs_type: "9p".to_string(),
             log_level: "info".to_string(),
+            share_pidns: false,
             debug: false,
         }
     }
@@ -66,6 +69,7 @@ impl TaskConfig {
             parse_cmdline!(param, SHAREFS_TYPE, config.sharefs_type, String::from);
             parse_cmdline!(param, LOG_LEVEL, config.log_level, String::from);
             parse_cmdline!(param, TASK_DEBUG, config.debug);
+            parse_cmdline!(param, SHARE_PIDNS, config.share_pidns);
         }
         Ok(config)
     }

--- a/vmm/task/src/debug.rs
+++ b/vmm/task/src/debug.rs
@@ -37,6 +37,7 @@ pub async fn listen_debug_console(addr: &str) -> Result<()> {
     tokio::spawn(async move {
         let mut incoming = l.incoming();
         while let Some(Ok(s)) = incoming.next().await {
+            debug!("get a debug console request");
             if let Err(e) = debug_console(s).await {
                 error!("failed to open debug console {:?}", e);
             }


### PR DESCRIPTION
Before starting the virtual machine, pay attention to the NamespaceMode setting of pid namespace in PodSandboxConfig. If it is set to "Pod", add task.share_pidns to the startup parameters of Kuasar's task.
When the task starts and detects the share_pidns parameter, create a pid ns when creating the shared namespace.
Since the pid ns needs to take effect on child processes, two forks are required. The process forked executes the pause function and does not exit anymore.