### PR TITLE
doc: update container runtime with prefix kuasar

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -9,7 +9,7 @@ Kuasar has make some changes on official containerd v1.7.0 based on commit:`1f23
 - `git` clone the codes of containerd fork version from kuasar repository.
 
 ```bash
-git clone https://github.com/kuasar-io/containerd.git
+git clone -b v0.2.0-kuasar https://github.com/kuasar-io/containerd.git
 cd containerd
 make
 make install

--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -27,8 +27,8 @@ Refer to the following configuration to modify the configuration file, default p
 [proxy_plugins.vmm]
   type = "sandbox"
   address = "/run/vmm-sandboxer.sock"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.vmm]
-  runtime_type = "io.containerd.kuasar.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-vmm]
+  runtime_type = "io.containerd.kuasar-vmm.v1"
   sandboxer = "vmm"
   io_type = "hvsock"
 ```
@@ -39,8 +39,8 @@ Refer to the following configuration to modify the configuration file, default p
 [proxy_plugins.quark]
   type = "sandbox"
   address = "/run/quark-sandboxer.sock"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.quark]
-  runtime_type = "io.containerd.quark.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-quark]
+  runtime_type = "io.containerd.kuasar-quark.v1"
   sandboxer = "quark"
 ```
 
@@ -50,8 +50,8 @@ Refer to the following configuration to modify the configuration file, default p
 [proxy_plugins.wasm]
   type = "sandbox"
   address = "/run/wasm-sandboxer.sock"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
-  runtime_type = "io.containerd.wasm.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-wasm]
+  runtime_type = "io.containerd.kuasar-wasm.v1"
   sandboxer = "wasm"
 ```
 

--- a/docs/vmm/how-to-run-kuasar-with-isulad-and-stratovirt.md
+++ b/docs/vmm/how-to-run-kuasar-with-isulad-and-stratovirt.md
@@ -115,7 +115,7 @@ Sine some code have not been merged into the upstream containerd community, so y
 
 git clone the codes of containerd fork version from kuasar repository.
 ```bash
-$ git clone https://github.com/kuasar-io/containerd.git
+$ git clone -b v0.2.0-kuasar https://github.com/kuasar-io/containerd.git
 $ cd containerd
 $ make bin/containerd
 $ install bin/containerd /usr/bin/containerd

--- a/docs/vmm/how-to-run-kuasar-with-isulad-and-stratovirt.md
+++ b/docs/vmm/how-to-run-kuasar-with-isulad-and-stratovirt.md
@@ -131,8 +131,8 @@ Add the following sandboxer config in the containerd config file `/etc/container
     type = "sandbox"
     address = "/run/vmm-sandboxer.sock"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.vmm]
-  runtime_type = "io.containerd.kuasar.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-vmm]
+  runtime_type = "io.containerd.kuasar-vmm.v1"
   sandboxer = "vmm"
   io_type = "hvsock"
 ```
@@ -240,11 +240,11 @@ linux:
   namespaces:
     options: {}
 
-$ crictl runp --runtime=vmm podsandbox.yaml
+$ crictl runp --runtime=kuasar-vmm podsandbox.yaml
 5cbcf744949d8500e7159d6bd1e3894211f475549c0be15d9c60d3c502c7ede3
 ```
 
-> Tips: `--runtime=vmm` indicates that containerd needs to use vmm-sandboxer runtime to run a pod sandbox
+> Tips: `--runtime=kuasar-vmm` indicates that containerd needs to use vmm-sandboxer runtime to run a pod sandbox
 
 - List pod sandboxes and check the sandbox is in Ready state:
 ```bash

--- a/examples/run_example_container.sh
+++ b/examples/run_example_container.sh
@@ -60,7 +60,7 @@ cat > container.json <<EOF
 }
 EOF
 
-# Run a container, default runtime is "vmm".
-runtime=${1:-vmm}
+# Run a container, default runtime is "kuasar-vmm".
+runtime=${1:-kuasar-vmm}
 crictl -r unix:///run/containerd/containerd.sock run --runtime="$runtime" container.json pod.json
 rm -f container.json pod.json

--- a/examples/run_example_wasm_container.sh
+++ b/examples/run_example_wasm_container.sh
@@ -75,5 +75,5 @@ cat > container.json <<EOF
 EOF
 
 # Run a wasm container
-crictl -r unix:///run/containerd/containerd.sock run --runtime="wasm" --no-pull container.json pod.json
+crictl -r unix:///run/containerd/containerd.sock run --runtime="kuasar-wasm" --no-pull container.json pod.json
 rm -f container.json pod.json

--- a/scripts/build/build-containerd.sh
+++ b/scripts/build/build-containerd.sh
@@ -28,17 +28,17 @@ disable_apparmor = true
 runtime_type = "io.containerd.runc.v2"
 sandboxer = "runc"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.vmm]
-runtime_type = "io.containerd.kuasar.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-vmm]
+runtime_type = "io.containerd.kuasar-vmm.v1"
 sandboxer = "vmm"
 io_type = "hvsock"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.quark]
-runtime_type = "io.containerd.quark.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-quark]
+runtime_type = "io.containerd.kuasar-quark.v1"
 sandboxer = "quark"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
-runtime_type = "io.containerd.wasm.v1"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kuasar-wasm]
+runtime_type = "io.containerd.kuasar-wasm.v1"
 sandboxer = "wasm"
 
 [proxy_plugins.vmm]

--- a/scripts/build/build-containerd.sh
+++ b/scripts/build/build-containerd.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-git clone https://github.com/kuasar-io/containerd.git 
+git clone -b v0.2.0-kuasar https://github.com/kuasar-io/containerd.git
 mkdir bin && make -C containerd bin/containerd && mv containerd/bin/containerd bin
 
 tee bin/config.toml > /dev/null <<EOF


### PR DESCRIPTION
1. Update container runtime with prefix "kuasar", e.g. "kuasar-vmm", "kuasar-wasm"
2. Update containerd to v0.2.0-kuasar tag since we have a set of new APIs.