### PR TITLE
vmm: support pod sysctl configuration

### DIFF
--- a/vmm/common/Cargo.toml
+++ b/vmm/common/Cargo.toml
@@ -21,3 +21,4 @@ regex = "1.5.6"
 
 [build-dependencies]
 ttrpc-codegen = { git = "https://github.com/kuasar-io/ttrpc-rust.git", branch = "v0.7.1-kuasar" }
+tonic-build = "0.7.2"

--- a/vmm/common/src/protos/sandbox.proto
+++ b/vmm/common/src/protos/sandbox.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 package grpc;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
 import "github.com/containerd/containerd/api/services/ttrpc/events/v1/events.proto";
 
 service SandboxService {
@@ -31,6 +32,7 @@ service SandboxService {
     rpc ExecVMProcess (ExecVMProcessRequest) returns (ExecVMProcessResponse);
     rpc SyncClock (SyncClockPacket) returns (SyncClockPacket);
     rpc GetEvents (google.protobuf.Empty) returns (containerd.services.events.ttrpc.v1.Envelope);
+    rpc SetupSandbox (SetupSandboxRequest) returns (google.protobuf.Empty);
 }
 
 message CheckRequest {
@@ -108,4 +110,10 @@ message UpdateInterfacesRequest {
 
 message UpdateRoutesRequest {
     repeated Route routes = 1;
+}
+
+message SetupSandboxRequest {
+    google.protobuf.Any config = 1;
+    repeated Interface interfaces = 2;
+    repeated Route routes = 3;
 }

--- a/vmm/sandbox/Cargo.lock
+++ b/vmm/sandbox/Cargo.lock
@@ -2724,6 +2724,7 @@ dependencies = [
  "protobuf 3.2.0",
  "regex",
  "serde",
+ "tonic-build",
  "ttrpc",
  "ttrpc-codegen 0.4.1",
 ]

--- a/vmm/sandbox/src/cloud_hypervisor/factory.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/factory.rs
@@ -22,7 +22,6 @@ use crate::{
         devices::{console::Console, fs::Fs, pmem::Pmem, rng::Rng, vsock::Vsock},
         CloudHypervisorVM,
     },
-    sandbox::has_shared_pid_namespace,
     utils::get_netns,
     vm::VMFactory,
 };
@@ -47,9 +46,6 @@ impl VMFactory for CloudHypervisorVMFactory {
     ) -> containerd_sandbox::error::Result<Self::VM> {
         let netns = get_netns(&s.sandbox);
         let mut vm = CloudHypervisorVM::new(id, &netns, &s.base_dir, &self.vm_config);
-        if has_shared_pid_namespace(&s.sandbox) {
-            vm.config.cmdline.push_str(" task.share_pidns")
-        }
         // add image as a disk
         if !self.vm_config.common.image_path.is_empty() {
             let rootfs_device = Pmem::new("rootfs", &self.vm_config.common.image_path, true);

--- a/vmm/task/Cargo.lock
+++ b/vmm/task/Cargo.lock
@@ -2196,6 +2196,7 @@ dependencies = [
  "protobuf 3.2.0",
  "regex",
  "serde",
+ "tonic-build",
  "ttrpc",
  "ttrpc-codegen 0.4.1",
 ]
@@ -2206,6 +2207,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "containerd-sandbox",
  "containerd-shim",
  "crossbeam",
  "env_logger",

--- a/vmm/task/Cargo.toml
+++ b/vmm/task/Cargo.toml
@@ -36,6 +36,7 @@ tokio-vsock = "0.3.1"
 pin-project-lite = "0.2.7"
 ttrpc = { version = "0.7", features = ["async"] }
 
+containerd-sandbox = { git = "https://github.com/kuasar-io/rust-extensions.git" }
 containerd-shim = { git = "https://github.com/kuasar-io/rust-extensions.git", features = ["async"] }
 runc = { git = "https://github.com/kuasar-io/rust-extensions.git", features = ["async"] }
 

--- a/vmm/task/src/config.rs
+++ b/vmm/task/src/config.rs
@@ -20,7 +20,6 @@ use tokio::fs::read_to_string;
 const SHAREFS_TYPE: &str = "task.sharefs_type";
 const LOG_LEVEL: &str = "task.log_level";
 const TASK_DEBUG: &str = "task.debug";
-const SHARE_PIDNS: &str = "task.share_pidns";
 
 macro_rules! parse_cmdline {
     ($param:ident, $key:ident, $field:expr) => {
@@ -42,7 +41,6 @@ macro_rules! parse_cmdline {
 pub struct TaskConfig {
     pub(crate) sharefs_type: String,
     pub(crate) log_level: String,
-    pub(crate) share_pidns: bool,
     pub(crate) debug: bool,
 }
 
@@ -51,7 +49,6 @@ impl Default for TaskConfig {
         TaskConfig {
             sharefs_type: "9p".to_string(),
             log_level: "info".to_string(),
-            share_pidns: false,
             debug: false,
         }
     }
@@ -69,7 +66,6 @@ impl TaskConfig {
             parse_cmdline!(param, SHAREFS_TYPE, config.sharefs_type, String::from);
             parse_cmdline!(param, LOG_LEVEL, config.log_level, String::from);
             parse_cmdline!(param, TASK_DEBUG, config.debug);
-            parse_cmdline!(param, SHARE_PIDNS, config.share_pidns);
         }
         Ok(config)
     }

--- a/vmm/task/src/sandbox.rs
+++ b/vmm/task/src/sandbox.rs
@@ -14,16 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{path::Path, time::Duration};
+use std::{collections::HashMap, os::fd::AsRawFd, path::Path, process::exit, time::Duration};
 
-use containerd_shim::{error::Error, other, other_error, util::IntoOption, Result};
+use containerd_sandbox::{cri::api::v1::NamespaceMode, PodSandboxConfig};
+use containerd_shim::{
+    error::Error,
+    io_error, other, other_error,
+    util::{mkdir, IntoOption},
+    Result,
+};
 use log::{debug, warn};
+use nix::{
+    sched::{unshare, CloneFlags},
+    unistd::{fork, getpid, pause, pipe, ForkResult, Pid},
+};
+use tokio::fs::File;
 use vmm_common::{
     mount::{mount, unmount},
     storage::{Storage, DRIVERBLKTYPE, DRIVEREPHEMERALTYPE, DRIVERSCSITYPE},
+    HOSTNAME_FILENAME, IPC_NAMESPACE, KUASAR_STATE_DIR, PID_NAMESPACE, SANDBOX_NS_PATH,
+    UTS_NAMESPACE,
 };
 
-use crate::device::{scan_scsi_bus, Device, DeviceMatcher, DeviceMonitor, DeviceType};
+use crate::{
+    device::{scan_scsi_bus, Device, DeviceMatcher, DeviceMonitor, DeviceType},
+    CLONE_FLAG_TABLE,
+};
 
 pub struct SandboxResources {
     storages: Vec<Storage>,
@@ -216,5 +232,162 @@ impl DeviceMatcher for TypeAddrDeviceMatcher {
             return true;
         }
         false
+    }
+}
+
+fn convert_sysctl_to_proc_path(sysctl: &str) -> String {
+    let base_path = "/proc/sys/";
+    let proc_path = sysctl.replace('.', "/");
+    format!("{}{}", base_path, proc_path)
+}
+
+async fn write_sysctl(sysctls: HashMap<String, String>) -> Result<()> {
+    for sysctl in sysctls {
+        tokio::fs::write(convert_sysctl_to_proc_path(&sysctl.0), &sysctl.1)
+            .await
+            .map_err(io_error!(
+                e,
+                "failed to set sysctl {} to {}",
+                &sysctl.0,
+                &sysctl.1
+            ))?;
+    }
+
+    Ok(())
+}
+
+fn fork_sandbox(ns_types: Vec<String>, clone_type: CloneFlags) -> Result<()> {
+    debug!("fork sandbox process {:?}, {:b}", ns_types, clone_type);
+    let (r, w) = pipe().map_err(other_error!(e, "create pipe when fork sandbox error"))?;
+    match unsafe { fork().map_err(other_error!(e, "failed to fork"))? } {
+        ForkResult::Parent { child } => {
+            debug!("forked process {} for the sandbox", child);
+            drop(w);
+            let mut resp = [0u8; 4];
+            // just wait the pipe close, do not care the read result
+            nix::unistd::read(r.as_raw_fd(), &mut resp).unwrap_or_default();
+            Ok(())
+        }
+        ForkResult::Child => {
+            drop(r);
+            unshare(clone_type).unwrap();
+            if !ns_types.iter().any(|n| n == PID_NAMESPACE) {
+                debug!("mount namespaces in child");
+                mount_ns(getpid(), &ns_types);
+                exit(0);
+            }
+            // if we need share pid ns, we fork a pause process to act as the pid 1 of the shared pid ns
+            match unsafe { fork().unwrap() } {
+                ForkResult::Parent { child } => {
+                    mount_ns(child, &ns_types);
+                    exit(0);
+                }
+                ForkResult::Child => {
+                    debug!("mount namespaces in grand child");
+                    drop(w);
+                    loop {
+                        pause();
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn mount_ns(pid: Pid, ns_types: &Vec<String>) {
+    if ns_types.iter().any(|n| n == UTS_NAMESPACE) {
+        let hostname = std::fs::read_to_string(Path::new(KUASAR_STATE_DIR).join(HOSTNAME_FILENAME))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        if !hostname.is_empty() {
+            debug!("set hostname for sandbox: {}", hostname);
+            nix::unistd::sethostname(hostname).unwrap();
+        }
+    }
+    for ns_type in ns_types {
+        let sandbox_ns_path = format!("{}/{}", SANDBOX_NS_PATH, ns_type);
+        let ns_path = format!("/proc/{}/ns/{}", pid, ns_type);
+        debug!("mount {} to {}", ns_path, sandbox_ns_path);
+        mount(
+            Some("none"),
+            Some(ns_path.as_str()),
+            &["bind".to_string()],
+            &sandbox_ns_path,
+        )
+        .unwrap();
+    }
+}
+
+async fn setup_sandbox_ns(config: &PodSandboxConfig) -> Result<()> {
+    let mut nss = vec![String::from(IPC_NAMESPACE), String::from(UTS_NAMESPACE)];
+
+    if let Some(pid_ns_mode) = config
+        .linux
+        .as_ref()
+        .and_then(|l| l.security_context.as_ref())
+        .and_then(|s| s.namespace_options.as_ref())
+        .map(|n| n.pid())
+    {
+        if pid_ns_mode == NamespaceMode::Pod {
+            nss.push(String::from(PID_NAMESPACE));
+        }
+    }
+
+    setup_persistent_ns(nss).await?;
+    Ok(())
+}
+
+async fn setup_persistent_ns(ns_types: Vec<String>) -> Result<()> {
+    if ns_types.is_empty() {
+        return Ok(());
+    }
+    mkdir(SANDBOX_NS_PATH, 0o711).await?;
+
+    let mut clone_type = CloneFlags::empty();
+
+    for ns_type in &ns_types {
+        let sandbox_ns_path = format!("{}/{}", SANDBOX_NS_PATH, ns_type);
+        File::create(&sandbox_ns_path).await.map_err(io_error!(
+            e,
+            "failed to create: {}",
+            sandbox_ns_path
+        ))?;
+
+        clone_type |= *CLONE_FLAG_TABLE
+            .get(ns_type)
+            .ok_or(other!("bad ns type {}", ns_type))?;
+    }
+
+    fork_sandbox(ns_types, clone_type)?;
+
+    Ok(())
+}
+
+pub async fn setup_sandbox(config: &PodSandboxConfig) -> Result<()> {
+    // Set sysctl
+    if let Some(linux) = &config.linux {
+        write_sysctl(linux.clone().sysctls).await?
+    }
+
+    // Set Network NS
+    setup_sandbox_ns(config).await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_sysctl_to_proc_path;
+
+    #[test]
+    fn test_convert_sysctl_to_proc_path() {
+        assert_eq!(
+            convert_sysctl_to_proc_path("kernel.version"),
+            "/proc/sys/kernel/version"
+        );
+        assert_eq!(
+            convert_sysctl_to_proc_path("net.ipv4.tcp_keepalive_time"),
+            "/proc/sys/net/ipv4/tcp_keepalive_time"
+        );
     }
 }


### PR DESCRIPTION
This PR adds support for configuring pod sysctl settings in the VMM (Virtual Machine Manager) component of our Kubernetes runtime project.

With this change, users can now specify custom sysctl settings for their pods, allowing for more fine-grained control over the runtime environment. This feature is particularly useful for workloads that require specific kernel parameter settings.

The implementation includes the necessary changes to the VMM codebase to parse and apply sysctl settings from the pod's configuration.