### PR TITLE
vmm: redirect virtiofsd log to syslog

### DIFF
--- a/vmm/sandbox/config_clh.toml
+++ b/vmm/sandbox/config_clh.toml
@@ -21,3 +21,4 @@ path = "/usr/local/bin/virtiofsd"
 log_level = "info"
 cache = "never"
 thread_pool_size = 4
+syslog = true

--- a/vmm/sandbox/src/cloud_hypervisor/config.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/config.rs
@@ -65,6 +65,8 @@ pub struct VirtiofsdConfig {
     pub socket_path: String,
     #[serde(default)]
     pub shared_dir: String,
+    #[serde(default)]
+    pub syslog: bool,
 }
 
 impl Default for VirtiofsdConfig {
@@ -76,6 +78,7 @@ impl Default for VirtiofsdConfig {
             thread_pool_size: 4,
             socket_path: "".to_string(),
             shared_dir: "".to_string(),
+            syslog: true,
         }
     }
 }

--- a/vmm/sandbox/src/cloud_hypervisor/mod.rs
+++ b/vmm/sandbox/src/cloud_hypervisor/mod.rs
@@ -134,6 +134,7 @@ impl CloudHypervisorVM {
         let pid = child
             .id()
             .ok_or(anyhow!("the virtiofsd has been polled to completion"))?;
+        info!("virtiofsd for {} is running with pid {}", self.id, pid);
         spawn_wait(child, format!("virtiofsd {}", self.id), None, None);
         Ok(pid)
     }
@@ -185,6 +186,11 @@ impl VM for CloudHypervisorVM {
                 .map_err(|e| anyhow!("failed to spawn cloud hypervisor command: {}", e))?
         };
         let pid = child.id();
+        info!(
+            "cloud hypervisor for {} is running with pid {}",
+            self.id,
+            pid.unwrap_or_default()
+        );
         self.pids.vmm_pid = pid;
         let pid_file = format!("{}/pid", self.base_dir);
         let (tx, rx) = channel((0u32, 0i128));


### PR DESCRIPTION
The current log output of virtiofsd is to stdout/stderr collected by its parents process vmm-sandboxer.
As a result, it will be lost if sandboxer process restarts. Redirecting virtiofsd log to syslog could make it persistent.

Virtiofsd already supports `--syslog` option: https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/61