### PR TITLE
vmm: Sync route flags

### DIFF
--- a/vmm/common/src/protos/sandbox.proto
+++ b/vmm/common/src/protos/sandbox.proto
@@ -102,6 +102,7 @@ message Route {
     string source = 4;
     uint32 scope = 5;
     IPFamily family = 6;
+    uint32 flags = 7;
 }
 
 message UpdateInterfacesRequest {

--- a/vmm/sandbox/Cargo.lock
+++ b/vmm/sandbox/Cargo.lock
@@ -1180,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "match_cfg"
@@ -1274,14 +1274,14 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6de2fe935f44cbdfcab77dce2150d68eda75be715cd42d4d6f52b0bd4dcc5b1"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
  "byteorder",
  "libc",
+ "log",
  "netlink-packet-core",
  "netlink-packet-utils",
 ]
@@ -1386,8 +1386,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
- "memoffset 0.6.5",
- "pin-utils",
 ]
 
 [[package]]
@@ -1402,6 +1400,17 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -1596,7 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.25.1",
+ "nix 0.28.0",
 ]
 
 [[package]]
@@ -1967,9 +1976,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
 dependencies = [
  "futures",
  "log",
@@ -1978,7 +1987,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.26.2",
+ "nix 0.27.1",
  "thiserror",
  "tokio",
 ]

--- a/vmm/sandbox/Cargo.toml
+++ b/vmm/sandbox/Cargo.toml
@@ -41,8 +41,8 @@ qapi = { version = "0.8.0", features = ["qmp", "async-tokio-all"] }
 qapi-spec = { version = "0.3.1" }
 sandbox-derive = { path = "derive" }
 api_client = { git = "https://github.com/cloud-hypervisor/cloud-hypervisor.git" }
-rtnetlink = "0.13.1"
-netlink-packet-route = "0.17.0"
+rtnetlink = "0.14.1"
+netlink-packet-route = "0.19.0"
 netlink-packet-core = "0.7.0"
 ttrpc = { version = "0.7", features = ["async"] }
 protobuf = "3.2"

--- a/vmm/sandbox/src/network/convert.rs
+++ b/vmm/sandbox/src/network/convert.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use netlink_packet_route::{AF_INET, AF_INET6};
+use netlink_packet_route::AddressFamily;
 use protobuf::{EnumOrUnknown, SpecialFields};
 use vmm_common::api::sandbox::{IPAddress, IPFamily, Interface, Route};
 
@@ -57,10 +57,10 @@ impl From<&crate::network::Route> for Route {
             gateway: r.gateway.to_string(),
             device: r.device.to_string(),
             source: r.source.to_string(),
-            scope: r.scope,
-            family: EnumOrUnknown::from(match r.family {
-                AF_INET => IPFamily::v4,
-                AF_INET6 => IPFamily::v6,
+            scope: r.scope as u32,
+            family: EnumOrUnknown::from(match AddressFamily::from(r.family) {
+                AddressFamily::Inet => IPFamily::v4,
+                AddressFamily::Inet6 => IPFamily::v6,
                 _ => IPFamily::default(),
             }),
             special_fields: Default::default(),

--- a/vmm/sandbox/src/network/convert.rs
+++ b/vmm/sandbox/src/network/convert.rs
@@ -63,6 +63,7 @@ impl From<&crate::network::Route> for Route {
                 AddressFamily::Inet6 => IPFamily::v6,
                 _ => IPFamily::default(),
             }),
+            flags: r.flags,
             special_fields: Default::default(),
         }
     }

--- a/vmm/sandbox/src/network/link.rs
+++ b/vmm/sandbox/src/network/link.rs
@@ -28,10 +28,9 @@ use anyhow::anyhow;
 use containerd_sandbox::error::Result;
 use futures_util::TryStreamExt;
 use libc::{IFF_MULTI_QUEUE, IFF_NO_PI, IFF_TAP, IFF_VNET_HDR};
-use netlink_packet_route::{
-    link::nlas::{Info, InfoData, InfoIpVlan, InfoKind, InfoMacVlan, InfoMacVtap, InfoVlan},
-    nlas::link::InfoVxlan,
-    LinkMessage,
+use netlink_packet_route::link::{
+    InfoData, InfoIpVlan, InfoKind, InfoMacVlan, InfoMacVtap, InfoVlan, InfoVxlan, LinkFlag,
+    LinkInfo, LinkMessage,
 };
 use nix::{
     ioctl_read_bad, ioctl_write_ptr_bad, libc,
@@ -44,7 +43,7 @@ use serde_derive::{Deserialize, Serialize};
 use crate::{
     device::{DeviceInfo, PhysicalDeviceInfo, TapDeviceInfo, VhostUserDeviceInfo},
     network::{
-        address::{convert_to_ip_address, CniIPAddress, IpNet, MacAddress},
+        address::{CniIPAddress, IpNet, MacAddress},
         create_netlink_handle, execute_in_netns, run_in_new_netns,
     },
     sandbox::KuasarSandbox,
@@ -98,7 +97,6 @@ pub enum LinkType {
     Ipvlan(u16),
     Macvlan(u32),
     Macvtap(u32),
-    Iptun,
     Tun,
     VhostUser(String),
     Physical(String, String),
@@ -124,7 +122,6 @@ impl Display for LinkType {
             LinkType::Ipvlan(_) => "ipvlan".to_string(),
             LinkType::Macvlan(_) => "macvlan".to_string(),
             LinkType::Macvtap(_) => "macvtap".to_string(),
-            LinkType::Iptun => "iptun".to_string(),
             LinkType::Tun => "tun".to_string(),
             LinkType::VhostUser(_) => "vhostuser".to_string(),
             LinkType::Physical(_, _) => "physical".to_string(),
@@ -167,7 +164,6 @@ impl From<InfoData> for LinkType {
                     return Self::Macvtap(*i);
                 }
             }
-            InfoData::IpTun(_) => return Self::Iptun,
             _ => return Self::Unkonwn,
         }
         Self::Unkonwn
@@ -210,6 +206,19 @@ pub struct NetworkInterface {
     pub queue: u32,
 }
 
+// netlink-packet-route-0.19.0/src/link/link_flag.rs:26
+pub(crate) struct VecLinkFlag(pub Vec<LinkFlag>);
+
+impl From<&VecLinkFlag> for u32 {
+    fn from(v: &VecLinkFlag) -> u32 {
+        let mut d: u32 = 0;
+        for flag in &v.0 {
+            d += u32::from(*flag);
+        }
+        d
+    }
+}
+
 impl NetworkInterface {
     pub async fn parse_from_message(
         msg: LinkMessage,
@@ -218,31 +227,31 @@ impl NetworkInterface {
         handle: &Handle,
     ) -> Result<Self> {
         let mut intf = NetworkInterface {
-            flags: msg.header.flags,
+            flags: u32::from(&VecLinkFlag(msg.header.flags)),
             index: msg.header.index,
             ..NetworkInterface::default()
         };
-        for nla in msg.nlas.into_iter() {
-            use netlink_packet_route::nlas::link::Nla;
-            match nla {
-                Nla::Info(infos) => {
+        use netlink_packet_route::link::LinkAttribute;
+        for attribute in msg.attributes.into_iter() {
+            match attribute {
+                LinkAttribute::LinkInfo(infos) => {
                     for info in infos {
-                        if let Info::Data(d) = info {
+                        if let LinkInfo::Data(d) = info {
                             intf.r#type = d.into();
-                        } else if let Info::Kind(InfoKind::Veth) = info {
-                            // for veth, there is no Info::Data, but SlaveKind and SlaveData
+                        } else if let LinkInfo::Kind(InfoKind::Veth) = info {
+                            // for veth, there is no Info::Data, but SlaveKind and SlaveData,
                             // so we have to get the type from Info::Kind
                             intf.queue = queue;
                             intf.r#type = LinkType::Veth;
                         }
                     }
                 }
-                Nla::IfName(s) => {
+                LinkAttribute::IfName(s) => {
                     intf.name = s;
                 }
-                Nla::IfAlias(a) => intf.alias = a,
-                Nla::Mtu(m) => intf.mtu = m,
-                Nla::Address(u) => intf.mac_address = MacAddress(u),
+                LinkAttribute::IfAlias(a) => intf.alias = a,
+                LinkAttribute::Mtu(m) => intf.mtu = m,
+                LinkAttribute::Address(u) => intf.mac_address = MacAddress(u),
                 _ => {}
             }
         }
@@ -252,10 +261,9 @@ impl NetworkInterface {
             .set_link_index_filter(msg.header.index)
             .execute();
         while let Some(msg) = addresses.try_next().await.map_err(|e| anyhow!(e))? {
-            use netlink_packet_route::nlas::address::Nla;
-            for nla in msg.nlas.into_iter() {
-                if let Nla::Address(addr) = nla {
-                    let address = convert_to_ip_address(addr)?;
+            use netlink_packet_route::address::AddressAttribute;
+            for nla in msg.attributes.into_iter() {
+                if let AddressAttribute::Address(address) = nla {
                     let mask_len = msg.header.prefix_len;
                     if address.is_loopback() {
                         intf.r#type = LinkType::Loopback;

--- a/vmm/sandbox/src/network/netlink.rs
+++ b/vmm/sandbox/src/network/netlink.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use futures_util::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST};
-use netlink_packet_route::{RtnlMessage, TcMessage};
+use netlink_packet_route::{tc::TcMessage, RouteNetlinkMessage};
 use rtnetlink::{try_nl, Error, Handle};
 
 const HANDLE_INGRESS: u32 = 0xfffffff1;
@@ -42,7 +42,7 @@ impl QDiscAddRequest {
             message,
         } = self;
 
-        let mut req = NetlinkMessage::from(RtnlMessage::NewQueueDiscipline(message));
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewQueueDiscipline(message));
         req.header.flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL | NLM_F_ACK;
 
         let mut response = handle.request(req)?;
@@ -58,7 +58,7 @@ impl QDiscAddRequest {
     }
 
     pub fn ingress(mut self) -> Self {
-        self.message.header.parent = HANDLE_INGRESS;
+        self.message.header.parent = HANDLE_INGRESS.into();
         self
     }
 }
@@ -73,7 +73,7 @@ impl TrafficFilterSetRequest {
     pub(crate) fn new(handle: Handle, ifindex: i32) -> Self {
         let mut message = TcMessage::default();
         message.header.index = ifindex;
-        message.header.parent = HANDLE_TC_FILTER;
+        message.header.parent = HANDLE_TC_FILTER.into();
 
         Self { handle, message }
     }
@@ -84,7 +84,7 @@ impl TrafficFilterSetRequest {
             message,
         } = self;
 
-        let mut req = NetlinkMessage::from(RtnlMessage::NewTrafficFilter(message));
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewTrafficFilter(message));
         req.header.flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL | NLM_F_ACK;
 
         let mut response = handle.request(req)?;

--- a/vmm/sandbox/src/network/route.rs
+++ b/vmm/sandbox/src/network/route.rs
@@ -35,6 +35,23 @@ pub struct Route {
     pub scope: u8,
     #[serde(default)]
     pub family: u8,
+    #[serde(default)]
+    pub flags: u32,
+}
+
+use netlink_packet_route::route::RouteFlag;
+
+// netlink-packet-route-0.19.0/src/route/flags.rs:87
+pub(crate) struct VecRouteFlag(pub(crate) Vec<RouteFlag>);
+
+impl From<&VecRouteFlag> for u32 {
+    fn from(v: &VecRouteFlag) -> u32 {
+        let mut d: u32 = 0;
+        for flag in &v.0 {
+            d += u32::from(*flag);
+        }
+        d
+    }
 }
 
 impl Route {
@@ -45,6 +62,7 @@ impl Route {
         let mut route = Route {
             scope: msg.header.scope.into(),
             family: msg.header.address_family.into(),
+            flags: u32::from(&VecRouteFlag(msg.header.flags)),
             ..Route::default()
         };
         use netlink_packet_route::route::RouteAttribute;

--- a/vmm/sandbox/src/network/route.rs
+++ b/vmm/sandbox/src/network/route.rs
@@ -16,7 +16,8 @@ limitations under the License.
 
 use anyhow::anyhow;
 use containerd_sandbox::error::Result;
-use netlink_packet_route::{RouteMessage, RT_TABLE_MAIN};
+use netlink_packet_route::route::RouteMessage;
+use nix::libc::RT_TABLE_MAIN;
 use serde_derive::{Deserialize, Serialize};
 
 use crate::network::{address::convert_to_ip_address, link::NetworkInterface};
@@ -31,9 +32,9 @@ pub struct Route {
     #[serde(default)]
     pub gateway: String,
     #[serde(default)]
-    pub scope: u32,
+    pub scope: u8,
     #[serde(default)]
-    pub family: u16,
+    pub family: u8,
 }
 
 impl Route {
@@ -42,24 +43,24 @@ impl Route {
             return Err(anyhow!("ignore routes not in main table").into());
         }
         let mut route = Route {
-            scope: msg.header.scope as u32,
-            family: msg.header.address_family as u16,
+            scope: msg.header.scope.into(),
+            family: msg.header.address_family.into(),
             ..Route::default()
         };
-        use netlink_packet_route::nlas::route::Nla;
-        for nla in msg.nlas.into_iter() {
-            match nla {
-                Nla::Destination(v) if !v.is_empty() => {
+        use netlink_packet_route::route::RouteAttribute;
+        for attribute in msg.attributes.into_iter() {
+            match attribute {
+                RouteAttribute::Destination(v) => {
                     let ip = convert_to_ip_address(v)?.to_string();
                     route.dest = format!("{}/{}", ip, msg.header.destination_prefix_length);
                 }
-                Nla::Source(v) if !v.is_empty() => {
+                RouteAttribute::Source(v) => {
                     route.source = convert_to_ip_address(v)?.to_string();
                 }
-                Nla::Gateway(v) if !v.is_empty() => {
+                RouteAttribute::Gateway(v) => {
                     route.gateway = convert_to_ip_address(v)?.to_string();
                 }
-                Nla::Oif(u) => {
+                RouteAttribute::Oif(u) => {
                     intfs
                         .iter()
                         .find(|&x| x.index == u)

--- a/vmm/task/Cargo.lock
+++ b/vmm/task/Cargo.lock
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matchit"
@@ -977,26 +977,25 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5cf0b54effda4b91615c40ff0fd12d0d4c9a6e0f5116874f03941792ff535a"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
  "byteorder",
- "libc",
  "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea993e32c77d87f01236c38f572ecb6c311d592e56a06262a007fd2a6e31253c"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
  "byteorder",
  "libc",
+ "log",
  "netlink-packet-core",
  "netlink-packet-utils",
 ]
@@ -1015,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26305d12193227ef7b8227e7d61ae4eaf174607f79bd8eeceff07aacaefde497"
+checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 dependencies = [
  "bytes 1.4.0",
  "futures",
@@ -1107,14 +1106,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cfg-if 1.0.0",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -1600,9 +1598,9 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rtnetlink"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7d42da676fdf7e470e2502717587dd1089d8b48d9d1b846dcc3c01072858cb"
+checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
 dependencies = [
  "futures",
  "log",
@@ -1611,7 +1609,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys 0.8.5",
- "nix 0.26.2",
+ "nix 0.27.1",
  "thiserror",
  "tokio",
 ]
@@ -1758,12 +1756,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/vmm/task/Cargo.toml
+++ b/vmm/task/Cargo.toml
@@ -20,9 +20,9 @@ crossbeam = "0.8.1"
 env_logger = "0.9.0"
 lazy_static = "1.4.0"
 netlink-sys = { version = "0.7.0", features = ["tokio_socket"] }
-rtnetlink = "0.12"
-netlink-packet-route = "0.15"
-netlink-packet-core = "0.5.0"
+rtnetlink = "0.14.1"
+netlink-packet-route = "0.19.0"
+netlink-packet-core = "0.7.0"
 ipnetwork = "0.20"
 anyhow = { version = "1.0.66", default-features = false, features = ["std", "backtrace"] }
 protobuf = "3.2"


### PR DESCRIPTION
CNI added the network route under pod namespace, in the vmm case, kuasar should sync the route of host OS to guest OS as well as flags of route, e.g. `onlink`.