### PR TITLE
add prefix `kuasar-` for container runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Since Kuasar is a low-level container runtime, all interactions should be done v
 
 + For vmm, quark or runc, run the following scripts:
 
-  `examples/run_example_container.sh vmm`, `examples/run_example_container.sh quark` or `examples/run_example_container.sh runc`
+  `examples/run_example_container.sh kuasar-vmm`, `examples/run_example_container.sh kuasar-quark` or `examples/run_example_container.sh kuasar-runc`
 
 + For wasm: Wasm container needs its own container image so our script has to build and import the container image at first.
 


### PR DESCRIPTION
The runtime names registered in containered have changed after Kuasar https://github.com/kuasar-io/kuasar/releases/tag/v1.0.0.

![image](https://github.com/user-attachments/assets/d83cfab4-0a53-4bf0-be26-55aee5368bf2)
