### PR TITLE
ci: add MSRV

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.74"
+components = ["rustfmt", "clippy", "llvm-tools"]

--- a/vmm/task/src/streaming.rs
+++ b/vmm/task/src/streaming.rs
@@ -436,10 +436,12 @@ impl AsyncRead for StreamingStdin {
     }
 }
 
+type Permit = Box<dyn Future<Output = Result<OwnedPermit<Vec<u8>>, SendError<()>>> + Send>;
+
 pin_project_lite::pin_project! {
     pub struct StreamingOutput {
         sender: Sender<Vec<u8>>,
-        permit: Option<Pin<Box<dyn Future<Output = Result<OwnedPermit<Vec<u8>>, SendError<()>>> + Send>>>,
+        permit: Option<Pin<Permit>>,
     }
 }
 


### PR DESCRIPTION
The CI occasionally fails due to updates in some lint rules, so we set **MSRV**(Minimum Supported Rust Version) to Rust 1.74 in order to pass it.