### PR TITLE
Update build.sh to fix build errors

### DIFF
--- a/vmm/scripts/image/build.sh
+++ b/vmm/scripts/image/build.sh
@@ -69,7 +69,7 @@ containerd)
 		--mount type=bind,src="${ROOTFS_DIR}",dst=/tmp/kuasar-rootfs,options=rbind:rw \
 		${IMAGE_NAME} \
 		${container_name} \
-		bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
+		/bin/bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
 	fn_check_result $? "ctr run ${container_name} return error!"
 	;;
 docker)
@@ -81,7 +81,7 @@ docker)
 		-v "${REPO_DIR}":/kuasar \
 		-v "${ROOTFS_DIR}":"/tmp/kuasar-rootfs" \
 		${IMAGE_NAME} \
-		bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
+		/bin/bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
 	fn_check_result $? "docker run ${container_name} return error!"
 	;;
 isulad)
@@ -94,7 +94,7 @@ isulad)
 		-v "${REPO_DIR}":/kuasar \
 		-v "${ROOTFS_DIR}":"/tmp/kuasar-rootfs" \
 		${IMAGE_NAME} \
-		bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
+		/bin/bash /kuasar/vmm/scripts/image/${GUESTOS_IMAGE}/build_rootfs.sh
 	fn_check_result $? "isula run ${container_name} return error!"
 	;;
 *)


### PR DESCRIPTION
Fixing #167, Using /bin/bash instead of bash to avoid build errors.