### PR TITLE
logfix:print warn instead of error when dir not found.

### DIFF
--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -90,8 +90,13 @@ where
         let mut subs = match tokio::fs::read_dir(dir).await {
             Ok(subs) => subs,
             Err(e) => {
-                error!("FATAL! read working dir {} for recovery: {}", dir, e);
-                return;
+                if e.kind() == ErrorKind::NotFound {
+                    warn!("WARN! read working dir {} for recovery: {}", dir, e);
+                    return;
+                } else {
+                    error!("FATAL! read working dir {} for recovery: {}", dir, e);
+                    return;
+                }
             }
         };
         while let Some(entry) = subs.next_entry().await.unwrap() {


### PR DESCRIPTION
vmm-sandboxer reports an error when we start it for the first time, because the "/run/kuasar-vmm" dir does not exist. But it's a normal situation.