### PR TITLE
Shorten tap name

### DIFF
--- a/vmm/sandbox/src/network/link.rs
+++ b/vmm/sandbox/src/network/link.rs
@@ -313,7 +313,7 @@ impl NetworkInterface {
         match &self.r#type {
             LinkType::Veth => {
                 let handle = create_netlink_handle(netns).await?;
-                let tap_name = format!("tap_kuasar_{}", self.index);
+                let tap_name = format!("tap_kua_{}", self.index);
                 let tap_intf =
                     create_tap_in_netns(netns, &tap_name, self.queue, self.mtu, &handle).await?;
                 tap_intf.add_qdisc_ingress(netns, &handle).await?;


### PR DESCRIPTION
The tap name must be less than 16 bytes, including the '\0' terminator. The prefix "tap_kuasar_" is too long, which affects the index size. When the index exceeds 9999, the tap name becomes invalid. Therefore, shorten the tap name prefix to "tap_kua_".