### PR TITLE
ci: update rust to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup toolchain install nightly --component rustfmt
+      - run: rustup show
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78"
+channel = "1.81"
 components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
update rust to 1.81 to support newest cargo-deny and clear clippy warning.
