### PR TITLE
vmm: fix recover failed when first start

### DIFF
--- a/vmm/sandbox/src/bin/cloud_hypervisor/main.rs
+++ b/vmm/sandbox/src/bin/cloud_hypervisor/main.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::path::Path;
+
 use clap::Parser;
 use vmm_common::{signal, trace};
 use vmm_sandboxer::{
@@ -52,7 +54,9 @@ async fn main() {
     });
 
     // Do recovery job
-    sandboxer.recover(&args.dir).await;
+    if Path::new(&args.dir).exists() {
+        sandboxer.recover(&args.dir).await;
+    }
 
     // Run the sandboxer
     containerd_sandbox::run(

--- a/vmm/sandbox/src/bin/stratovirt/main.rs
+++ b/vmm/sandbox/src/bin/stratovirt/main.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::path::Path;
+
 use clap::Parser;
 use vmm_common::{signal, trace};
 use vmm_sandboxer::{
@@ -53,7 +55,9 @@ async fn main() {
     });
 
     // Do recovery job
-    sandboxer.recover(&args.dir).await;
+    if Path::new(&args.dir).exists() {
+        sandboxer.recover(&args.dir).await;
+    }
 
     // Run the sandboxer
     containerd_sandbox::run(


### PR DESCRIPTION
When first start on a node, kuasar-vmm will fail because the work dir is not created, so we first determin if the dir exist and then call the recover.