### PR TITLE
Fix Release Workflow and Update Kernel Compilation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Build vmm sandboxer
         run: make bin/vmm-sandboxer HYPERVISOR=${{ matrix.hypervisor }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vmm-sandboxer ${{ matrix.hypervisor }}
           path: |
@@ -39,7 +39,7 @@ jobs:
       - name: Build vm image
         run: sudo make bin/kuasar.img RUNTIME=docker
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: image
           path: bin/kuasar.img
@@ -55,7 +55,7 @@ jobs:
       - name: Build vm kernel
         run: make bin/vmlinux.bin HYPERVISOR=${{ matrix.hypervisor }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kernel ${{ matrix.hypervisor }}
           path: bin/vmlinux.bin
@@ -68,7 +68,7 @@ jobs:
       - name: Build quark
         run: make quark
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: quark
           path: bin/quark-sandboxer
@@ -90,7 +90,7 @@ jobs:
       - name: Build wasm
         run: make wasm WASM_RUNTIME=${{ matrix.features }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasm-sandboxer ${{ matrix.features }}
           path: bin/wasm-sandboxer
@@ -103,7 +103,7 @@ jobs:
       - name: Build runc
         run: make runc
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: runc
           path: bin/runc-sandboxer
@@ -117,7 +117,7 @@ jobs:
         run: ./scripts/build/build-containerd.sh
         shell: bash
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: containerd
           path: |
@@ -149,7 +149,7 @@ jobs:
           sudo -E chown -R root:root /tmp/${dir}
           mkdir _release
           sudo -E tar -czf _release/${dir}.tar.gz -C /tmp/ ${dir}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: _artifacts
       - name: Package binaries

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HYPERVISOR ?= cloud_hypervisor
 GUESTOS_IMAGE ?= centos
 WASM_RUNTIME ?= wasmedge
-KERNEL_VERSION ?= 6.2
+KERNEL_VERSION ?= 6.12.8
 ARCH ?= x86_64
 # DEST_DIR is used when built with RPM format
 DEST_DIR ?= /

--- a/vmm/scripts/kernel/cloud_hypervisor/build.sh
+++ b/vmm/scripts/kernel/cloud_hypervisor/build.sh
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 set -e
+set -x
 
-readonly version=${1:-6.1.6}
+readonly version=${1:-6.12.8}
 readonly base_dir="$(dirname $(readlink -f $0))"
 
 sudo apt-get update
@@ -25,12 +26,9 @@ sudo apt-get install -y libelf-dev elfutils
 rm -rf /tmp/linux-cloud-hypervisor
 git clone --depth 1 https://github.com/cloud-hypervisor/linux.git -b ch-${version} /tmp/linux-cloud-hypervisor
 pushd /tmp/linux-cloud-hypervisor
-wget --no-check-certificate https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/main/resources/linux-config-x86_64
-# TODO support arm
-# wget https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/main/resources/linux-config-aarch64
-cp linux-config-x86_64 .config  # x86-64
-# TODO support arm
-# cp linux-config-aarch64 .config # AArch64
+make ch_defconfig
+
+# Do native build of the x86-64 kernel
 KCFLAGS="-Wa,-mx86-used-note=no" make bzImage -j `nproc`
 # TODO support arm
 # make -j `nproc`


### PR DESCRIPTION
## Description

This PR addresses two key improvements to our build and release processes:

1. Updates the release workflow to use the latest version of the upload-artifact GitHub Action (v4)
2. Adapts our kernel compilation process to be compatible with the latest version of cloud-hypervisor

These changes ensure our release pipeline remains reliable and compatible with our current dependencies.

## Testing

- Verified that artifacts are correctly uploaded in the release workflow: [release workflow test](https://github.com/morningtzh/kuasar/actions/runs/13968515602)
- Tested kernel compilation with the latest cloud-hypervisor version
- Confirmed that the generated kernel works as expected in our environment

## Related Issues

This PR addresses ongoing maintenance needs and does not correspond to a specific issue.