### PR TITLE
​​ci: use cargo-deny without version pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: cargo clippy ${{ matrix.features }} -- -D warnings
       - name: Deny
         working-directory: ${{ matrix.directories }}
-        run: cargo install cargo-deny@0.15.1 && cargo deny -L warn ${{ matrix.features }} check
+        run: cargo install cargo-deny && cargo deny -L warn ${{ matrix.features }} check
 
   tests:
     strategy:


### PR DESCRIPTION
Update CI configuration to use the latest cargo-deny version instead of pinning to legacy 0.15.1