### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81"
+channel = "1.88"
 components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
Upgrade the Rust toolchain version from `1.81` to `1.88`