### PR TITLE
ci:updata rust to 1.85

### DIFF
--- a/quark/src/sandbox.rs
+++ b/quark/src/sandbox.rs
@@ -209,7 +209,7 @@ impl Sandbox for QuarkSandbox {
         return Ok(());
     }
 
-    async fn container(&self, id: &str) -> Result<&Self::Container> {
+    async fn container<'a>(&'a self, id: &str) -> Result<&'a Self::Container> {
         self.containers
             .get(id)
             .ok_or(Error::NotFound(format!("no container id {} found", id)))
@@ -403,10 +403,9 @@ impl QuarkSandbox {
     }
 
     fn container_mut(&mut self, id: &str) -> Result<&mut <Self as Sandbox>::Container> {
-        return self
-            .containers
+        self.containers
             .get_mut(id)
-            .ok_or(Error::NotFound(format!("no container id {} found", id)));
+            .ok_or(Error::NotFound(format!("no container id {} found", id)))
     }
 }
 

--- a/runc/src/sandbox.rs
+++ b/runc/src/sandbox.rs
@@ -347,7 +347,7 @@ impl Sandbox for RuncSandbox {
         Ok(())
     }
 
-    async fn container(&self, id: &str) -> Result<&Self::Container> {
+    async fn container<'a>(&'a self, id: &str) -> Result<&'a Self::Container> {
         return self.containers.get(id).ok_or(Error::NotFound(format!(
             "failed to find container by id {id}"
         )));

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81"
+channel = "1.85"
 components = ["rustfmt", "clippy", "llvm-tools"]

--- a/vmm/sandbox/src/network/mod.rs
+++ b/vmm/sandbox/src/network/mod.rs
@@ -148,11 +148,11 @@ impl Network {
     }
 
     pub fn interfaces(&self) -> &Vec<NetworkInterface> {
-        return self.intfs.as_ref();
+        self.intfs.as_ref()
     }
 
     pub fn routes(&self) -> &Vec<Route> {
-        return self.routes.as_ref();
+        self.routes.as_ref()
     }
 
     fn filter_intfs(intfs: Vec<NetworkInterface>) -> Vec<NetworkInterface> {

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -331,7 +331,7 @@ where
     }
 
     #[instrument(skip_all)]
-    async fn container(&self, id: &str) -> Result<&Self::Container> {
+    async fn container<'a>(&'a self, id: &str) -> Result<&'a Self::Container> {
         let container = self
             .containers
             .get(id)

--- a/vmm/sandbox/src/utils.rs
+++ b/vmm/sandbox/src/utils.rs
@@ -101,8 +101,7 @@ pub fn get_dns_config(data: &SandboxData) -> Option<&DnsConfig> {
 }
 
 pub fn get_total_resources(data: &SandboxData) -> Option<LinuxContainerResources> {
-    return data
-        .config
+    data.config
         .as_ref()
         .and_then(|c| c.linux.as_ref())
         .and_then(|l| {
@@ -114,7 +113,7 @@ pub fn get_total_resources(data: &SandboxData) -> Option<LinuxContainerResources
                 l.resources.as_ref().unwrap(),
                 l.overhead.as_ref().unwrap(),
             ))
-        });
+        })
 }
 
 fn merge_resources(

--- a/wasm/src/sandbox.rs
+++ b/wasm/src/sandbox.rs
@@ -219,7 +219,7 @@ impl Sandbox for WasmSandbox {
         Ok(())
     }
 
-    async fn container(&self, id: &str) -> Result<&Self::Container> {
+    async fn container<'a>(&'a self, id: &str) -> Result<&'a Self::Container> {
         self.containers.get(id).ok_or(Error::NotFound(format!(
             "failed to find container by id {id}"
         )))


### PR DESCRIPTION
update rust to 1.81 to support newest cargo-deny and clear clippy warning.