### PR TITLE
vmm/task: fix stdout stream handoff and cleanup

### DIFF
--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -168,8 +168,7 @@ create_container_config() {
   "linux": {
     "security_context": {
       "namespace_options": {
-        "network": 2,
-        "pid": 1
+        "network": 2
       }
     }
   }
@@ -584,6 +583,14 @@ run_all_tests() {
         test_kuasar_ctl_no_proc_leak \
         test_vmm_killed_cleanup
 
+    source "${script_dir}/test_exec_streams.sh"
+    run_test_group "Streaming I/O Edge Cases" \
+        test_exec_stream_disconnect_loop \
+        test_exec_exit_drain_stdout \
+        test_exec_exit_drain_stderr \
+        test_exec_stdin_boundaries \
+        test_exec_stdin_eof \
+        test_containerd_restart_log_resume
     if [[ ${#test_failures[@]} -ne 0 ]]; then
         echo "1..${tap_count}" >> "${tap_file}"
         die "CRI tests failed: ${test_failures[*]}"

--- a/tests/integration/cri-containerd/test_exec_streams.sh
+++ b/tests/integration/cri-containerd/test_exec_streams.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+# This script is sourced by integration-tests.sh and relies on its variables and helper functions.
+
+wait_for_log_seq_gt() {
+    local cid="$1"
+    local min_seq="${2:--1}"
+    local retries="${3:-20}"
+    local delay="${4:-0.5}"
+    local seq=-1
+
+    for _ in $(seq 1 "${retries}"); do
+        seq="$(
+            sudo crictl logs "${cid}" 2>/dev/null | \
+                awk '/^SEQ[[:space:]][0-9]+([[:space:]]|$)/ { seq=$2 } END { print (seq == "" ? -1 : seq) }'
+        )"
+        if [[ ${seq} -gt ${min_seq} ]]; then
+            printf '%s\n' "${seq}"
+            return 0
+        fi
+        sleep "${delay}"
+    done
+
+    printf '%s\n' "${seq}"
+    return 1
+}
+
+# Verify IOChannel recovery and no panics when client disconnects (graceful exit vs abrupt kill).
+# 1. Start crictl exec producing continuous output.
+# 2. Loop 50 times, alternating between graceful exit and abrupt client kill.
+# 3. Check sandbox stability to ensure subsequent execs respond normally.
+test_exec_stream_disconnect_loop() {
+    local max_iters=50
+    local log_dir="${ARTIFACTS_DIR}/exec_disconnect"
+    mkdir -p "${log_dir}"
+    
+    log "Running crictl exec disconnect loop for ${max_iters} iterations..."
+    
+    for i in $(seq 1 "${max_iters}"); do
+        if (( i % 5 == 0 )); then
+            # Graceful exit: command finishes by itself
+            sudo crictl exec "${container_id}" sh -c "echo 'graceful'; sleep 0.2" > "${log_dir}/exec_${i}.log" 2>&1
+        else
+            # Abrupt kill: kill the crictl exec process while it's receiving output
+            sudo crictl exec "${container_id}" sh -c "while true; do echo 'alive'; sleep 0.05; done" > "${log_dir}/exec_${i}.log" 2>&1 &
+            local exec_pid=$!
+            sleep 0.3
+            sudo kill -9 "${exec_pid}" >/dev/null 2>&1 || true
+            wait "${exec_pid}" 2>/dev/null || true
+        fi
+    done
+    
+    local ping_out
+    ping_out=$(sudo crictl exec "${container_id}" sh -c 'echo pong' 2>&1)
+    [[ "${ping_out}" == "pong" ]] || die "Sandbox unstable after disconnect loop: got ${ping_out}"
+}
+
+# Verify stdout draining completes before process exit for fast-exiting tasks.
+# 1. Generate 10MB of deterministic data using awk and exit immediately.
+# 2. Redirect output to a file on the host.
+# 3. Validate file size (exactly 10MB) and SHA256 hash integrity.
+test_exec_exit_drain_stdout() {
+    local out_file="${ARTIFACTS_DIR}/drain_stdout.bin"
+    
+    log "Testing stdout draining upon fast process exit"
+    
+    sudo crictl exec "${container_id}" sh -c 'awk "BEGIN{for(i=0;i<10240;i++) printf \"%1024s\", \"\" | \"tr \\\" \\\" \\\"A\\\"\"}"' > "${out_file}"
+    
+    local file_size
+    file_size=$(stat -c %s "${out_file}")
+    [[ "${file_size}" -eq 10485760 ]] || die "Stdout drain failed, expected 10485760 bytes, got ${file_size}"
+    
+    local hash_val
+    hash_val=$(sha256sum "${out_file}" | awk '{print $1}')
+    local expected_hash="eb6183addde05c2196ce25e6fa34a4baf20f9bf30d33892f452a9a1e88c9a472"
+    [[ "${hash_val}" == "${expected_hash}" ]] || die "Stdout drain hash mismatch"
+}
+
+# Verify stderr draining completes before process exit to ensure API refactoring coverage.
+# 1. Direct 10MB test data to stderr and exit immediately.
+# 2. Capture stderr on the host using 2>&1 redirection.
+# 3. Validate the consistency of the received file size.
+test_exec_exit_drain_stderr() {
+    local out_file="${ARTIFACTS_DIR}/drain_stderr.bin"
+    
+    log "Testing stderr draining upon fast process exit"
+    
+    sudo crictl exec "${container_id}" sh -c 'awk "BEGIN{for(i=0;i<10240;i++) printf \"%1024s\", \"\" | \"tr \\\" \\\" \\\"B\\\"\"}" >&2' > "${out_file}" 2>&1
+    
+    local file_size
+    file_size=$(stat -c %s "${out_file}")
+    [[ "${file_size}" -eq 10485760 ]] || die "Stderr drain failed, expected 10485760 bytes, got ${file_size}"
+    
+    local hash_val
+    hash_val=$(sha256sum "${out_file}" | awk '{print $1}')
+    local expected_hash="4206ae362958087f93cacff490e2922d285b5fa018faeaa13804e8b98ea36a6e"
+    [[ "${hash_val}" == "${expected_hash}" ]] || die "Stderr drain hash mismatch"
+}
+
+# Verify StreamingStdin boundary handling (64KiB +/- 1) and chunk merging logic.
+# 1. Prepare deterministic payloads with special sizes: 64KiB-1, 64KiB+1, 1MiB+17B.
+# 2. Stream into the container via crictl exec -i.
+# 3. Compare SHA256 hashes between host source and guest destination files.
+test_exec_stdin_boundaries() {
+    log "Testing StreamingStdin overlapping boundaries"
+    
+    local boundary_sizes=(65535 65537 1048593)
+    
+    for b_size in "${boundary_sizes[@]}"; do
+        local in_file="${ARTIFACTS_DIR}/stdin_bound_${b_size}.bin"
+        dd if=/dev/urandom of="${in_file}" bs=1 count="${b_size}" status=none
+        local expected_hash
+        expected_hash=$(sha256sum "${in_file}" | awk '{print $1}')
+        
+        sudo crictl exec -i "${container_id}" sh -c "cat > /tmp/out_${b_size}.bin" < "${in_file}"
+        
+        local guest_hash
+        guest_hash=$(sudo crictl exec "${container_id}" sha256sum "/tmp/out_${b_size}.bin" | awk '{print $1}')
+        
+        [[ "${expected_hash}" == "${guest_hash}" ]] || die "Stdin boundary match failed for size ${b_size}: host ${expected_hash}, guest ${guest_hash}"
+    done
+}
+
+# Verify that leftover data in the Stdin buffer is drained correctly upon EOF.
+# 1. Send a string to the container and close the input pipe.
+# 2. Verify the guest process reads the full string rather than hanging on an incomplete chunk.
+# 3. Implement a 5-second timeout as a safety guard.
+test_exec_stdin_eof() {
+    log "Testing stdin residual buffer draining on EOF"
+    
+    local stdout_file="${ARTIFACTS_DIR}/stdin_eof_out.txt"
+    printf %s "kuasar-eof-test" | sudo timeout 5s crictl exec -i "${container_id}" cat > "${stdout_file}"
+    local rc=$?
+    
+    [[ ${rc} -eq 0 ]] || die "crictl exec timeout or failed with rc=${rc} when testing EOF"
+    
+    local output
+    output=$(cat "${stdout_file}")
+    [[ "${output}" == "kuasar-eof-test" ]] || die "EOF leftover buffering failed, got: ${output}"
+}
+
+# Verify that container stdout logging resumes correctly after the containerd service restarts.
+# 1. Start a container outputting timestamps and verify initial log rolling.
+# 2. Force kill and restart the containerd daemon.
+# 3. Assert that crictl logs -f continues to receive new log lines after reconciliation.
+test_containerd_restart_log_resume() {
+    log "Testing containerd restart logging continuity"
+
+    local c_config="${ARTIFACTS_DIR}/log-test.json"
+    local p_config="${ARTIFACTS_DIR}/podsandbox.json"
+    local inspect_file="${ARTIFACTS_DIR}/failed_inspect_log_resume.json"
+    local stalled_logs_file="${ARTIFACTS_DIR}/stalled_logs_log_resume.txt"
+    
+    create_podsandbox_config "${p_config}"
+    cat > "${c_config}" <<'EOFCFG'
+{
+  "metadata": { "name": "log-resume", "namespace": "default" },
+  "image": { "image": "docker.io/library/busybox:1.36.1" },
+  "command": ["sh", "-c", "i=0; while true; do echo \"SEQ $i $(date)\"; i=$((i+1)); sleep 0.2; done"],
+  "log_path": "log.txt",
+  "linux": { "security_context": { "namespace_options": { "network": 2 } } }
+}
+EOFCFG
+
+    local cid
+    local seq_before
+    local seq_after
+    cid="$(sudo crictl create "${pod_id}" "${c_config}" "${p_config}")"
+    sudo crictl start "${cid}"
+
+    if ! seq_before="$(wait_for_log_seq_gt "${cid}")"; then
+        log "DIAGNOSTIC: No initial SEQ log lines found for ${cid}. Inspecting..."
+        sudo crictl inspect "${cid}" > "${inspect_file}" 2>&1 || true
+        sudo crictl ps -a --id "${cid}" >> "${inspect_file}" 2>&1 || true
+        die "No initial sequenced logs found for container ${cid}"
+    fi
+
+    log "Restarting containerd..."
+    [[ -f "${containerd_pid_file}" ]] && sudo kill -9 "$(cat "${containerd_pid_file}")" >/dev/null 2>&1 || true
+    sleep 1
+    start_containerd
+
+    if ! seq_after="$(wait_for_log_seq_gt "${cid}" "${seq_before}")"; then
+        log "DIAGNOSTIC: Logs stalled. Before seq: ${seq_before}, After seq: ${seq_after}. Logs dump:"
+        sudo crictl logs "${cid}" >> "${stalled_logs_file}" 2>&1 || true
+        die "Logs did not advance after containerd restart: before_seq=${seq_before}, after_seq=${seq_after}"
+    fi
+
+    log "Logs resumed properly (before seq: ${seq_before}, after seq: ${seq_after})"
+    sudo crictl rm -f "${cid}" >/dev/null 2>&1 || true
+}

--- a/vmm/task/src/io.rs
+++ b/vmm/task/src/io.rs
@@ -53,7 +53,7 @@ use tokio_vsock::{VsockListener, VsockStream};
 
 use crate::{
     device::SYSTEM_DEV_PATH,
-    streaming::{get_output, get_stdin, remove_channel},
+    streaming::{close_output, get_output, get_stdin, remove_channel},
     vsock,
 };
 
@@ -246,42 +246,44 @@ where
 {
     let src = from;
     tokio::spawn(async move {
-        let dst: Box<dyn AsyncWrite + Unpin + Send> = if to.contains(STREAMING) {
-            match get_output(&to).await {
-                Ok(output) => Box::new(output),
-                Err(e) => {
-                    error!("failed to get streaming by {}, {}", to, e);
-                    return;
-                }
-            }
-        } else if to.contains(VSOCK) {
-            tokio::select! {
-                _ = exit_signal.wait() => {
-                    debug!("container already exited, maybe nobody should connect vsock");
-                    return;
-                },
-                res = VsockIo::new(&to, true) => {
-                    match res {
-                        Ok(v) => Box::new(v),
-                        Err(e) => {
-                            error!("failed to new vsock {}, {:?}", to, e);
-                            return;
-                        },
+        {
+            let dst: Box<dyn AsyncWrite + Unpin + Send> = if to.contains(STREAMING) {
+                match get_output(&to).await {
+                    Ok(output) => Box::new(output),
+                    Err(e) => {
+                        error!("failed to get streaming by {}, {}", to, e);
+                        return;
                     }
                 }
-            }
-        } else {
-            match OpenOptions::new().write(true).open(to.as_str()).await {
-                Ok(f) => Box::new(f),
-                Err(e) => {
-                    error!("failed to get open file {}, {}", to, e);
-                    return;
+            } else if to.contains(VSOCK) {
+                tokio::select! {
+                    _ = exit_signal.wait() => {
+                        debug!("container already exited, maybe nobody should connect vsock");
+                        return;
+                    },
+                    res = VsockIo::new(&to, true) => {
+                        match res {
+                            Ok(v) => Box::new(v),
+                            Err(e) => {
+                                error!("failed to new vsock {}, {:?}", to, e);
+                                return;
+                            },
+                        }
+                    }
                 }
-            }
-        };
-        copy(src, dst, exit_signal, on_close).await;
+            } else {
+                match OpenOptions::new().write(true).open(to.as_str()).await {
+                    Ok(f) => Box::new(f),
+                    Err(e) => {
+                        error!("failed to get open file {}, {}", to, e);
+                        return;
+                    }
+                }
+            };
+            copy(src, dst, exit_signal, on_close).await;
+        }
         if to.contains(STREAMING) {
-            remove_channel(&to).await.unwrap_or_default();
+            close_output(&to).await.unwrap_or_default();
         }
         debug!("finished copy io from container to {}", to);
     });
@@ -468,6 +470,80 @@ async fn find_serial_dev(serial_name: &str) -> Result<String> {
         }
     }
     Err(other!("failed to get serial dev of name {}", serial_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+
+    use crate::streaming::{
+        close_output, get_output, remove_channel,
+        tests::{has_channel, insert_channel, output_url},
+    };
+
+    #[tokio::test]
+    async fn test_close_output_channel_cleanup() {
+        enum Action {
+            DropWriterBeforeClose,
+            WriteThenCloseBeforeDrop,
+        }
+
+        struct TestCase {
+            name: &'static str,
+            action: Action,
+            expect_present_after_close: bool,
+        }
+
+        let cases = vec![
+            TestCase {
+                name: "streaming_output_is_dropped_before_close",
+                action: Action::DropWriterBeforeClose,
+                expect_present_after_close: false,
+            },
+            TestCase {
+                name: "close_before_drop_leaves_channel_present",
+                action: Action::WriteThenCloseBeforeDrop,
+                expect_present_after_close: true,
+            },
+        ];
+
+        for tc in cases {
+            let url = output_url(tc.name);
+            let stream_id = format!("{}-stdout", tc.name);
+            insert_channel(&stream_id).await;
+
+            let mut output = Some(get_output(&url).await.unwrap());
+
+            match tc.action {
+                Action::DropWriterBeforeClose => {
+                    drop(output.take());
+                    close_output(&url).await.unwrap();
+                }
+                Action::WriteThenCloseBeforeDrop => {
+                    output.as_mut().unwrap().write_all(b"hello").await.unwrap();
+                    close_output(&url).await.unwrap();
+                }
+            }
+
+            assert_eq!(
+                has_channel(&stream_id).await,
+                tc.expect_present_after_close,
+                "case '{}' channel presence after close mismatch",
+                tc.name
+            );
+
+            if tc.expect_present_after_close {
+                drop(output.take());
+                remove_channel(&url).await.unwrap();
+
+                assert!(
+                    !has_channel(&stream_id).await,
+                    "case '{}' cleanup should remove the test channel",
+                    tc.name
+                );
+            }
+        }
+    }
 }
 
 pin_project_lite::pin_project! {

--- a/vmm/task/src/streaming.rs
+++ b/vmm/task/src/streaming.rs
@@ -80,6 +80,7 @@ pub struct IOChannel {
     remaining_data: Option<Any>,
     preemption_sender: Option<Sender<()>>,
     notifier: Arc<Notify>,
+    sender_closed: bool,
 }
 
 pub struct PreemptableReceiver {
@@ -116,6 +117,7 @@ impl IOChannel {
             remaining_data: None,
             preemption_sender: None,
             notifier: Arc::new(Notify::new()),
+            sender_closed: false,
         }
     }
 
@@ -138,7 +140,16 @@ impl IOChannel {
     fn return_preempted_receiver(&mut self, r: PreemptableReceiver, remaining_data: Option<Any>) {
         self.receiver = Some(r.receiver);
         self.remaining_data = remaining_data;
-        self.notifier.notify_one();
+    }
+
+    fn should_remove_closed_channel(&self) -> bool {
+        self.sender_closed
+            && self.remaining_data.is_none()
+            && self
+                .receiver
+                .as_ref()
+                .map(|receiver| receiver.is_closed() && receiver.is_empty())
+                .unwrap_or(false)
     }
 }
 
@@ -188,11 +199,22 @@ impl Service {
     }
 
     async fn preempt_receiver(&self, id: &str) -> ttrpc::Result<PreemptableReceiver> {
-        for _i in 0..10 {
+        for i in 0..10 {
             let mut ios = self.ios.lock().await;
-            let ch = ios.entry(id.to_string()).or_insert(IOChannel::new());
-            let notifier = ch.notifier.clone();
-            if let Some(c) = ch.get_or_preempt_receiver().await {
+
+            let (notifier, c) = if i == 0 {
+                let ch = ios.entry(id.to_string()).or_insert(IOChannel::new());
+                (ch.notifier.clone(), ch.get_or_preempt_receiver().await)
+            } else if let Some(ch) = ios.get_mut(id) {
+                (ch.notifier.clone(), ch.get_or_preempt_receiver().await)
+            } else {
+                return Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
+                    ttrpc::Code::NOT_FOUND,
+                    "channel removed because stream finished",
+                )));
+            };
+
+            if let Some(c) = c {
                 debug!("io channel {} being preempted", id);
                 return Ok(c);
             }
@@ -214,10 +236,18 @@ impl Service {
         remaining_data: Option<Any>,
     ) {
         let mut ios = self.ios.lock().await;
+        let mut remove_channel = false;
         if let Some(ch) = ios.get_mut(id) {
             ch.return_preempted_receiver(r, remaining_data);
+            if ch.should_remove_closed_channel() {
+                remove_channel = true;
+            }
+            ch.notifier.notify_one();
         } else {
             warn!("io channel removed when return the receiver");
+        }
+        if remove_channel {
+            ios.remove(id);
         }
     }
 
@@ -271,6 +301,19 @@ impl Service {
         self.ios.lock().await.remove(id);
     }
 
+    async fn close_output_channel(&self, id: &str) {
+        let mut ios = self.ios.lock().await;
+        let remove_channel = if let Some(ch) = ios.get_mut(id) {
+            ch.sender_closed = true;
+            ch.should_remove_closed_channel()
+        } else {
+            false
+        };
+        if remove_channel {
+            ios.remove(id);
+        }
+    }
+
     async fn handle_stdin(
         &self,
         stream_id: &String,
@@ -286,18 +329,14 @@ impl Service {
                     Ok(d) => d,
                     Err(e) => {
                         debug!("failed to marshal update of stream {}, {}", stream_id, e);
-                        if let Some(c) = self.ios.lock().await.get_mut(stream_id) {
-                            c.sender = Some(sender);
-                        }
+                        self.ios.lock().await.remove(stream_id);
                         return Err(ttrpc::Error::Others(format!("failed to write data {}", e)));
                     }
                 };
                 let a = new_any!(WindowUpdate, update_bytes);
                 if let Err(e) = stream.send(&a).await {
                     debug!("failed to send update of stream {}, {}", stream_id, e);
-                    if let Some(c) = self.ios.lock().await.get_mut(stream_id) {
-                        c.sender = Some(sender);
-                    }
+                    self.ios.lock().await.remove(stream_id);
                     return Err(e);
                 }
                 window += WINDOW_SIZE;
@@ -313,6 +352,7 @@ impl Service {
                     };
                     let len: i32 = data_bytes.len().try_into().unwrap_or_default();
                     if let Err(e) = sender.send(data_bytes).await {
+                        self.ios.lock().await.remove(stream_id);
                         return Err(ttrpc::Error::Others(format!("failed to send data {}", e)));
                     }
                     window -= len;
@@ -330,9 +370,24 @@ impl Service {
         stream_id: &String,
         stream: ServerStream<Any, Any>,
     ) -> ttrpc::Result<()> {
-        let mut receiver = self.preempt_receiver(stream_id).await?;
+        let (stream_sender, mut stream_receiver) = stream.split();
+        let mut receiver = match self.preempt_receiver(stream_id).await {
+            Ok(r) => r,
+            Err(e) => {
+                if let ttrpc::Error::RpcStatus(ref status) = e {
+                    if status.code == ttrpc::Code::NOT_FOUND.into() {
+                        debug!(
+                            "stdout stream {} finished before we could take over",
+                            stream_id
+                        );
+                        return Ok(());
+                    }
+                }
+                return Err(e);
+            }
+        };
         if let Some(a) = self.get_remaining_data(stream_id).await {
-            if let Err(e) = stream.send(&a).await {
+            if let Err(e) = stream_sender.send(&a).await {
                 debug!("failed to send data of stream {}, {}", stream_id, e);
                 self.return_preempted_receiver(stream_id, receiver, Some(a))
                     .await;
@@ -340,17 +395,43 @@ impl Service {
             }
         }
         loop {
-            let r = if let Ok(res) = receiver.recv().await {
-                res
-            } else {
-                self.return_preempted_receiver(stream_id, receiver, None)
-                    .await;
-                info!("stream {} is preempted", stream_id);
-                return Err(ttrpc::Error::Others("channel is preempted".to_string()));
+            let r = select! {
+                res = receiver.recv() => {
+                    match res {
+                        Ok(output) => output,
+                        Err(_) => {
+                            self.return_preempted_receiver(stream_id, receiver, None)
+                                .await;
+                            info!("stream {} is preempted", stream_id);
+                            return Err(ttrpc::Error::Others("channel is preempted".to_string()));
+                        }
+                    }
+                }
+                client = stream_receiver.recv() => {
+                    match client {
+                        Ok(None) => {
+                            debug!("stdout stream {} is closed by client", stream_id);
+                            self.return_preempted_receiver(stream_id, receiver, None)
+                                .await;
+                            return Ok(());
+                        }
+                        Ok(Some(_)) => {
+                            debug!("stdout stream {} received unexpected client message", stream_id);
+                            continue;
+                        }
+                        Err(e) => {
+                            debug!("failed to receive client close signal of stream {}, {}", stream_id, e);
+                            self.return_preempted_receiver(stream_id, receiver, None)
+                                .await;
+                            return Err(e);
+                        }
+                    }
+                }
             };
             match r {
                 Some(d) => {
                     if d.is_empty() {
+                        self.remove_io_channel(stream_id).await;
                         return Ok(());
                     }
                     let mut data = Data::new();
@@ -368,7 +449,7 @@ impl Service {
                         }
                     };
                     let a = new_any!(Data, data_bytes);
-                    match stream.send(&a).await {
+                    match stream_sender.send(&a).await {
                         Ok(_) => {}
                         Err(e) => {
                             debug!("failed to send data of stream {}, {}", stream_id, e);
@@ -379,6 +460,7 @@ impl Service {
                     };
                 }
                 None => {
+                    self.remove_io_channel(stream_id).await;
                     return Ok(());
                 }
             }
@@ -394,6 +476,12 @@ pub async fn get_stdin(url: &str) -> containerd_shim::Result<StreamingStdin> {
 pub async fn remove_channel(url: &str) -> containerd_shim::Result<()> {
     let id = get_id(url)?;
     STREAMING_SERVICE.remove_io_channel(id).await;
+    Ok(())
+}
+
+pub async fn close_output(url: &str) -> containerd_shim::Result<()> {
+    let id = get_id(url)?;
+    STREAMING_SERVICE.close_output_channel(id).await;
     Ok(())
 }
 
@@ -429,6 +517,8 @@ impl AsyncRead for StreamingStdin {
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         let this = self.project();
+        let mut read_some = false;
+
         if let Some((data, offset)) = this.remaining.take() {
             let len = std::cmp::min(data.len() - offset, buf.remaining());
             buf.put_slice(&data[offset..offset + len]);
@@ -436,26 +526,36 @@ impl AsyncRead for StreamingStdin {
             if new_offset < data.len() {
                 *this.remaining = Some((data, new_offset));
             }
-            return Poll::Ready(Ok(()));
+            read_some = true;
         }
 
-        loop {
-            let r = ready!(this.receiver.poll_recv(cx));
-            match r {
-                Some(a) => {
-                    if a.is_empty() {
-                        continue;
+        if buf.remaining() > 0 {
+            loop {
+                match this.receiver.poll_recv(cx) {
+                    Poll::Ready(Some(a)) => {
+                        if a.is_empty() {
+                            continue;
+                        }
+                        let len = std::cmp::min(a.len(), buf.remaining());
+                        buf.put_slice(&a[..len]);
+                        if len < a.len() {
+                            *this.remaining = Some((a, len));
+                        }
+                        return Poll::Ready(Ok(()));
                     }
-                    let len = std::cmp::min(a.len(), buf.remaining());
-                    buf.put_slice(&a[..len]);
-                    if len < a.len() {
-                        *this.remaining = Some((a, len));
+                    Poll::Ready(None) => return Poll::Ready(Ok(())),
+                    Poll::Pending => {
+                        if read_some {
+                            return Poll::Ready(Ok(()));
+                        } else {
+                            return Poll::Pending;
+                        }
                     }
-                    return Poll::Ready(Ok(()));
                 }
-                None => return Poll::Ready(Ok(())),
             }
         }
+
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -507,8 +607,10 @@ impl AsyncWrite for StreamingOutput {
 }
 
 #[cfg(test)]
-mod tests {
-    use tokio::io::AsyncReadExt;
+pub(crate) mod tests {
+    use std::{collections::HashMap, sync::Arc, time::Duration};
+
+    use tokio::{io::AsyncReadExt, sync::Mutex, time::timeout};
 
     use super::*;
 
@@ -606,5 +708,314 @@ mod tests {
                 }
             }
         }
+    }
+
+    pub(crate) async fn insert_channel(id: &str) {
+        super::STREAMING_SERVICE
+            .ios
+            .lock()
+            .await
+            .insert(id.to_string(), IOChannel::new());
+    }
+
+    pub(crate) async fn has_channel(id: &str) -> bool {
+        super::STREAMING_SERVICE.ios.lock().await.contains_key(id)
+    }
+
+    pub(crate) fn output_url(id: &str) -> String {
+        format!("ttrpc+hvsock://test/stream?id={id}-stdout")
+    }
+
+    fn new_service() -> Service {
+        Service {
+            ios: Arc::new(Mutex::new(HashMap::default())),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_io_channel_cleanup() {
+        use vmm_common::api::any::Any;
+        let service = new_service();
+
+        #[derive(Debug)]
+        enum Action {
+            ReturnReceiver { remaining_data: bool },
+            CloseOutputChannel,
+        }
+
+        struct TestCase {
+            name: &'static str,
+            initial_state: fn(&mut IOChannel),
+            take_receiver: bool,
+            take_preemption_sender: bool,
+            action: Action,
+            expect_removed: bool,
+        }
+
+        let cases = vec![
+            TestCase {
+                name: "return_drained_and_closed_removes_channel",
+                initial_state: |ch| {
+                    ch.sender.take();
+                    ch.sender_closed = true;
+                },
+                take_receiver: true,
+                take_preemption_sender: false,
+                action: Action::ReturnReceiver {
+                    remaining_data: false,
+                },
+                expect_removed: true,
+            },
+            TestCase {
+                name: "return_not_drained_keeps_channel",
+                initial_state: |ch| {
+                    ch.sender_closed = true;
+                },
+                take_receiver: true,
+                take_preemption_sender: false,
+                action: Action::ReturnReceiver {
+                    remaining_data: true,
+                },
+                expect_removed: false,
+            },
+            TestCase {
+                name: "return_removes_even_if_preemption_sender_taken",
+                initial_state: |ch| {
+                    ch.sender.take();
+                    ch.sender_closed = true;
+                },
+                take_receiver: true,
+                take_preemption_sender: true,
+                action: Action::ReturnReceiver {
+                    remaining_data: false,
+                },
+                expect_removed: true,
+            },
+            TestCase {
+                name: "explicit_close_removes_drained_channel",
+                initial_state: |ch| {
+                    ch.sender.take();
+                },
+                take_receiver: false,
+                take_preemption_sender: false,
+                action: Action::CloseOutputChannel,
+                expect_removed: true,
+            },
+        ];
+
+        for tc in cases {
+            let stream_id = tc.name;
+            {
+                let mut ios = service.ios.lock().await;
+                let mut ch = IOChannel::new();
+                (tc.initial_state)(&mut ch);
+                ios.insert(stream_id.to_string(), ch);
+            }
+
+            let receiver = if tc.take_receiver {
+                let r = service.preempt_receiver(stream_id).await.unwrap();
+                if tc.take_preemption_sender {
+                    let mut ios = service.ios.lock().await;
+                    ios.get_mut(stream_id).unwrap().preemption_sender.take();
+                }
+                Some(r)
+            } else {
+                None
+            };
+
+            match tc.action {
+                Action::ReturnReceiver { remaining_data } => {
+                    let data = if remaining_data {
+                        Some(Any::new())
+                    } else {
+                        None
+                    };
+                    timeout(
+                        Duration::from_millis(200),
+                        service.return_preempted_receiver(stream_id, receiver.unwrap(), data),
+                    )
+                    .await
+                    .expect("return_preempted_receiver should not deadlock");
+                }
+                Action::CloseOutputChannel => {
+                    service.close_output_channel(stream_id).await;
+                }
+            }
+
+            let ios = service.ios.lock().await;
+            assert_eq!(
+                ios.get(stream_id).is_none(),
+                tc.expect_removed,
+                "Case '{}' failed: expected removed = {}",
+                tc.name,
+                tc.expect_removed
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_return_preempted_receiver_notifies_waiting_preemptor_after_sender_closed() {
+        let service = new_service();
+        let stream_id = "test-stderr";
+        service
+            .ios
+            .lock()
+            .await
+            .insert(stream_id.to_string(), IOChannel::new());
+
+        let receiver = service.preempt_receiver(stream_id).await.unwrap();
+        {
+            let mut ios = service.ios.lock().await;
+            let channel = ios.get_mut(stream_id).unwrap();
+            channel.sender.take();
+            channel.sender_closed = true;
+        }
+
+        let waiting_service = service.clone();
+        let waiting =
+            tokio::spawn(async move { waiting_service.preempt_receiver(stream_id).await });
+
+        tokio::task::yield_now().await;
+
+        service
+            .return_preempted_receiver(stream_id, receiver, None)
+            .await;
+
+        match timeout(Duration::from_millis(200), waiting).await {
+            Ok(Ok(Err(ttrpc::Error::RpcStatus(status)))) => {
+                assert_eq!(status.code, ttrpc::Code::NOT_FOUND.into());
+                assert_eq!(status.message, "channel removed because stream finished");
+            }
+            Ok(Ok(Err(e))) => panic!("preemptor should observe stream completion: {}", e),
+            Ok(Ok(Ok(_))) => panic!("preemptor should not take over a removed channel"),
+            Ok(Err(e)) => panic!("preempt task should join successfully: {}", e),
+            Err(_) => panic!("waiting preemptor should be notified"),
+        };
+    }
+
+    #[tokio::test]
+    async fn test_streaming_stdin_read() {
+        struct TestCase {
+            name: &'static str,
+            inputs: Vec<Vec<u8>>,
+            read_bufs: Vec<usize>,
+            expected: Vec<Vec<u8>>,
+        }
+
+        let cases = vec![
+            TestCase {
+                name: "single_full_read",
+                inputs: vec![vec![1, 2, 3]],
+                read_bufs: vec![3],
+                expected: vec![vec![1, 2, 3]],
+            },
+            TestCase {
+                name: "partial_read_from_one_chunk",
+                inputs: vec![vec![1, 2, 3, 4, 5]],
+                read_bufs: vec![3, 2],
+                expected: vec![vec![1, 2, 3], vec![4, 5]],
+            },
+            TestCase {
+                name: "multiple_chunks_read",
+                inputs: vec![vec![1, 2], vec![3, 4]],
+                read_bufs: vec![2, 2],
+                expected: vec![vec![1, 2], vec![3, 4]],
+            },
+            TestCase {
+                name: "read_larger_than_chunk",
+                inputs: vec![vec![1, 2]],
+                read_bufs: vec![4],
+                expected: vec![vec![1, 2]],
+            },
+            TestCase {
+                name: "read_overlapping_chunks",
+                inputs: vec![vec![1, 2, 3], vec![4, 5, 6]],
+                read_bufs: vec![2, 4],
+                expected: vec![vec![1, 2], vec![3, 4, 5, 6]],
+            },
+        ];
+
+        for tc in cases {
+            let (tx, rx) = tokio::sync::mpsc::channel(tc.inputs.len() + 1);
+            let mut stdin = StreamingStdin {
+                receiver: rx,
+                remaining: None,
+            };
+
+            for input in tc.inputs {
+                tx.send(input).await.unwrap();
+            }
+
+            for (i, &buf_len) in tc.read_bufs.iter().enumerate() {
+                let mut buf = vec![0u8; buf_len];
+                let n = stdin.read(&mut buf).await.unwrap();
+                assert_eq!(
+                    n,
+                    tc.expected[i].len(),
+                    "case '{}' read size mismatch at index {}",
+                    tc.name,
+                    i
+                );
+                assert_eq!(
+                    &buf[..n],
+                    &tc.expected[i][..],
+                    "case '{}' content mismatch at index {}",
+                    tc.name,
+                    i
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_stdin_read_leftover_then_eof() {
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        let mut stdin = StreamingStdin {
+            receiver: rx,
+            remaining: None,
+        };
+
+        tx.send(vec![1, 2, 3]).await.unwrap();
+        drop(tx);
+
+        let mut first = vec![0u8; 2];
+        let n = stdin.read(&mut first).await.unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(&first[..n], &[1, 2]);
+
+        let mut second = vec![0u8; 2];
+        let n = stdin.read(&mut second).await.unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(&second[..n], &[3]);
+
+        let mut third = vec![0u8; 2];
+        let n = stdin.read(&mut third).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_stdin_zero_length_read_keeps_buffered_data() {
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        let mut stdin = StreamingStdin {
+            receiver: rx,
+            remaining: Some((vec![7, 8, 9], 0)),
+        };
+
+        tx.send(vec![1, 2, 3]).await.unwrap();
+        drop(tx);
+
+        let mut empty = [];
+        let n = stdin.read(&mut empty).await.unwrap();
+        assert_eq!(n, 0);
+
+        let mut buf = vec![0u8; 3];
+        let n = stdin.read(&mut buf).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&buf[..n], &[7, 8, 9]);
+
+        let mut next = vec![0u8; 3];
+        let n = stdin.read(&mut next).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&next[..n], &[1, 2, 3]);
     }
 }


### PR DESCRIPTION
## Background
This change is a relay follow-up to #202.

Observed issue: `crictl exec -it xx ls` is a short-lived command, and it would occasionally return with no output.


## Summary

This change simplifies and hardens the `vmm-task` streaming handoff path for stdout/stderr, and tightens stdin read behavior for partial-buffer reads.

The main fixes are:

- handle output client disconnects while a stream handoff is in progress
- keep the preemption handoff path from stalling after the output sender has already closed
- remove closed output channels only after they are fully drained
- preserve unread stdin bytes across partial `AsyncRead` calls
- rename the public helper from `close_stdout` to `close_output` to match its actual use for both stdout and stderr

```mermaid
flowchart TD
    S1[Created]
    S2[Producer Attached]
    S3[Consumer Attached]
    S4[Buffered For Reattach<br/>remaining_data=Some]
    S5[Preempt Requested]
    S6[Producer Closed - Draining<br/>sender_closed=true]
    S7[Removed]
    N1[Waiting Preemptor Retries]
    E1[preempt_receiver returns NOT_FOUND]
    O1[handle_stdout returns Ok]

    S1 -->|get_output| S2
    S1 -.->|preempt_receiver first attach| S3
    S2 -->|preempt_receiver| S3
    S6 -->|preempt_receiver| S3

    S3 -->|stream_sender.send fails| S4
    S4 -->|next handle_stdout flushes remaining_data first| S3

    S3 -->|new consumer arrives| S5
    S5 -->|return receiver, rem_data=None, sender_closed=false| S2
    S5 -->|return receiver, rem_data=Some| S4
    S5 -->|return receiver, rem_data=None, sender_closed=true, drained=no| S6
    S5 -->|return receiver, rem_data=None, sender_closed=true, drained=yes| S7

    S2 -->|close_output, drained=no| S6
    S2 -->|close_output, drained=yes| S7
    S3 -->|close_output marks sender_closed=true| S3
    S4 -->|close_output marks sender_closed=true| S4

    S3 -->|client closes stream| S5
    S3 -->|marshal fails, receiver returned| S5

    S3 -->|receiver.recv returns empty| S7
    S3 -->|receiver.recv returns None| S7

    S6 -->|remaining_data cleared and receiver drained| S7

    S7 -->|waiting preemptor retries| N1
    N1 -->|channel missing| E1
    E1 -->|handle_stdout treats finished stream as normal completion| O1

```

