### PR TITLE
ci: add cri-containerd smoke workflow

### DIFF
--- a/.github/workflows/build-vmm-artifacts.yml
+++ b/.github/workflows/build-vmm-artifacts.yml
@@ -1,0 +1,186 @@
+name: Build VMM Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      hypervisor:
+        required: false
+        type: string
+        default: clh
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.hypervisor }}-build
+  cancel-in-progress: true
+
+jobs:
+  build-vmm-artifacts:
+    name: build-vmm-artifacts (${{ inputs.hypervisor }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set hypervisor variables
+        run: |
+          case "${{ inputs.hypervisor }}" in
+            clh)
+              echo "MAKE_HYPERVISOR=cloud_hypervisor" >> "$GITHUB_ENV"
+              echo "CONFIG_FILE=vmm/sandbox/config_clh.toml" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "unsupported hypervisor: ${{ inputs.hypervisor }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Setup Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v5.0.2
+        with:
+          go-version: '1.22'
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            libseccomp-dev \
+            protobuf-compiler \
+            curl \
+            git \
+            qemu-utils \
+            flex \
+            bison \
+            bc \
+            libelf-dev \
+            libssl-dev
+      - name: Extract versions from Makefile
+        run: |
+          KERNEL_VERSION=$(grep "KERNEL_VERSION ?=" Makefile | awk '{print $3}')
+          GUESTOS_IMAGE=$(grep "GUESTOS_IMAGE ?=" Makefile | awk '{print $3}')
+          echo "KERNEL_VERSION=${KERNEL_VERSION}" >> "$GITHUB_ENV"
+          echo "GUESTOS_IMAGE=${GUESTOS_IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Restore Kernel Artifact Cache
+        id: cache-kernel
+        uses: actions/cache/restore@v4
+        with:
+          path: bin/vmlinux.bin
+          key: vmlinux-${{ inputs.hypervisor }}-${{ hashFiles('vmm/scripts/kernel/**', 'Makefile') }}-${{ env.KERNEL_VERSION }}
+
+      - name: Restore VM Image Cache
+        id: cache-image
+        uses: actions/cache/restore@v4
+        with:
+          path: bin/kuasar.img
+          key: vmm-img-${{ inputs.hypervisor }}-${{ env.GUESTOS_IMAGE }}-${{ hashFiles('vmm/task/**', 'Cargo.lock', 'vmm/scripts/image/**', 'Makefile') }}
+
+      - name: Restore Sandboxer Artifact Cache
+        id: cache-sandboxer
+        uses: actions/cache/restore@v4
+        with:
+          path: bin/vmm-sandboxer
+          key: sandboxer-${{ inputs.hypervisor }}-${{ hashFiles('vmm/sandbox/**', 'vmm/common/**', 'Cargo.lock', 'Makefile') }}
+
+      - name: Restore kuasar-ctl Cache
+        id: cache-ctl
+        uses: actions/cache/restore@v4
+        with:
+          path: bin/kuasar-ctl
+          key: kuasar-ctl-${{ hashFiles('tools/kuasar-ctl/**', 'Cargo.lock', 'Makefile') }}
+
+      - name: Build vmm sandboxer
+        if: steps.cache-sandboxer.outputs.cache-hit != 'true'
+        run: |
+          make HYPERVISOR="${MAKE_HYPERVISOR}" bin/vmm-sandboxer
+
+      - name: Save Sandboxer Artifact Cache
+        if: steps.cache-sandboxer.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: bin/vmm-sandboxer
+          key: ${{ steps.cache-sandboxer.outputs.cache-primary-key }}
+
+      - name: Build kuasar-ctl
+        if: steps.cache-ctl.outputs.cache-hit != 'true'
+        run: |
+          make bin/kuasar-ctl
+
+      - name: Save kuasar-ctl Cache
+        if: steps.cache-ctl.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: bin/kuasar-ctl
+          key: ${{ steps.cache-ctl.outputs.cache-primary-key }}
+
+      - name: Build vm image
+        if: steps.cache-image.outputs.cache-hit != 'true'
+        run: |
+          # The guest image builder shells out to ctr by default. In GitHub
+          # Actions the root-owned containerd socket is not accessible to the
+          # unprivileged runner user, so reuse the repository's release flow.
+          sudo make bin/kuasar.img RUNTIME=docker
+
+      - name: Save VM Image Cache
+        if: steps.cache-image.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: bin/kuasar.img
+          key: ${{ steps.cache-image.outputs.cache-primary-key }}
+
+      - name: Build vm kernel
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        run: |
+          make HYPERVISOR="${MAKE_HYPERVISOR}" bin/vmlinux.bin
+
+      - name: Save Kernel Artifact Cache
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: bin/vmlinux.bin
+          key: ${{ steps.cache-kernel.outputs.cache-primary-key }}
+
+      - name: Restore containerd Cache
+        id: cache-containerd
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            bin/containerd
+            bin/config.toml
+          key: containerd-${{ hashFiles('scripts/build/build-containerd.sh') }}
+
+      - name: Build Kuasar containerd binary and config
+        if: steps.cache-containerd.outputs.cache-hit != 'true'
+        run: |
+          bash scripts/build/build-containerd.sh
+
+      - name: Save containerd Cache
+        if: steps.cache-containerd.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            bin/containerd
+            bin/config.toml
+          key: ${{ steps.cache-containerd.outputs.cache-primary-key }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vmm-artifacts-${{ inputs.hypervisor }}
+          path: |
+            bin/containerd
+            bin/config.toml
+            bin/vmm-sandboxer
+            bin/vmlinux.bin
+            bin/kuasar.img
+            bin/kuasar-ctl
+            ${{ env.CONFIG_FILE }}
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,8 +47,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v3
+      - name: Restore Cargo dependencies
+        id: cache-framework
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -60,6 +61,16 @@ jobs:
 
       - name: Build e2e test framework
         run: make -f  Makefile.e2e build-e2e
+
+      - name: Save Cargo dependencies
+        if: steps.cache-framework.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            tests/e2e/target
+          key: ${{ steps.cache-framework.outputs.cache-primary-key }}
 
       - name: Run framework unit tests
         run: make -f  Makefile.e2e test-e2e-framework
@@ -85,8 +96,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v3
+      - name: Restore Cargo dependencies
+        id: cache-integration
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -160,6 +172,18 @@ jobs:
       
       - name: Setup e2e environment
         run: make -f  Makefile.e2e setup-e2e-env-ci
+
+      - name: Save Cargo dependencies
+        if: steps.cache-integration.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            tests/e2e/target
+            runc/target
+            shim/target
+          key: ${{ steps.cache-integration.outputs.cache-primary-key }}
 
       - name: Run runc e2e tests
         env:

--- a/.github/workflows/run-vmm-e2e.yml
+++ b/.github/workflows/run-vmm-e2e.yml
@@ -1,0 +1,60 @@
+name: Run VMM E2E
+
+on:
+  workflow_call:
+    inputs:
+      hypervisor:
+        required: false
+        type: string
+        default: clh
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.hypervisor }}-run
+  cancel-in-progress: true
+
+jobs:
+  run-vmm-e2e:
+    name: run-vmm-e2e (${{ inputs.hypervisor }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: vmm-artifacts-${{ inputs.hypervisor }}
+          path: artifacts
+
+      - name: Install test dependencies
+        env:
+          HYPERVISOR: ${{ inputs.hypervisor }}
+        run: |
+          bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+
+      - name: Install Kuasar artifacts
+        env:
+          HYPERVISOR: ${{ inputs.hypervisor }}
+          KUASAR_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+        run: |
+          bash tests/integration/cri-containerd/gha-run.sh install-kuasar
+
+      - name: Run cri-containerd smoke test
+        env:
+          HYPERVISOR: ${{ inputs.hypervisor }}
+          ARTIFACTS_DIR: ${{ github.workspace }}/_artifacts/vmm-${{ inputs.hypervisor }}-cri-containerd
+        run: |
+          bash tests/integration/cri-containerd/gha-run.sh run
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vmm-e2e-${{ inputs.hypervisor }}-${{ github.run_number }}
+          path: _artifacts/
+          retention-days: 7

--- a/.github/workflows/vmm-ci-on-push.yml
+++ b/.github/workflows/vmm-ci-on-push.yml
@@ -1,0 +1,42 @@
+name: VMM CI
+
+on:
+  pull_request:
+    paths:
+      - 'vmm/**'
+      - 'tests/integration/cri-containerd/**'
+      - 'scripts/build/build-containerd.sh'
+      - '.github/workflows/build-vmm-artifacts.yml'
+      - '.github/workflows/run-vmm-e2e.yml'
+      - '.github/workflows/vmm-ci-on-push.yml'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'vmm/**'
+      - 'tests/integration/cri-containerd/**'
+      - 'scripts/build/build-containerd.sh'
+      - '.github/workflows/build-vmm-artifacts.yml'
+      - '.github/workflows/run-vmm-e2e.yml'
+      - '.github/workflows/vmm-ci-on-push.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-vmm-artifacts:
+    uses: ./.github/workflows/build-vmm-artifacts.yml
+    with:
+      hypervisor: clh
+
+  run-vmm-e2e:
+    needs: build-vmm-artifacts
+    uses: ./.github/workflows/run-vmm-e2e.yml
+    with:
+      hypervisor: clh

--- a/scripts/build/build-containerd.sh
+++ b/scripts/build/build-containerd.sh
@@ -13,12 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -euo pipefail
 
-git clone -b v0.2.0-kuasar https://github.com/kuasar-io/containerd.git
-mkdir bin && make -C containerd bin/containerd && mv containerd/bin/containerd bin
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
 
-tee bin/config.toml > /dev/null <<EOF
+git clone --depth 1 -b v0.2.0-kuasar https://github.com/kuasar-io/containerd.git "${tmp_dir}/containerd"
+mkdir -p "${repo_root}/bin"
+make -C "${tmp_dir}/containerd" bin/containerd
+mv "${tmp_dir}/containerd/bin/containerd" "${repo_root}/bin/containerd"
+
+tee "${repo_root}/bin/config.toml" > /dev/null <<EOF
 version = 3
 
 [plugins.'io.containerd.cri.v1.runtime']

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly repo_root="$(cd "${script_dir}/../../.." && pwd -P)"
+readonly artifact_dir_default="${repo_root}/artifacts"
+
+export HYPERVISOR="${HYPERVISOR:-clh}"
+export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${repo_root}/_artifacts/vmm-${HYPERVISOR}-cri-containerd}"
+export KUASAR_ARTIFACTS_DIR="${KUASAR_ARTIFACTS_DIR:-${artifact_dir_default}}"
+export CRICTL_VERSION="${CRICTL_VERSION:-v1.29.0}"
+export CNI_PLUGINS_VERSION="${CNI_PLUGINS_VERSION:-v1.2.0}"
+export CLOUD_HYPERVISOR_VERSION="${CLOUD_HYPERVISOR_VERSION:-v48.0}"
+
+log() {
+    printf '[cri-containerd] %s\n' "$*"
+}
+
+die() {
+    printf '[cri-containerd] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+resolve_hypervisor_config() {
+    case "${HYPERVISOR}" in
+        clh)
+            printf '%s\n' 'vmm/sandbox/config_clh.toml'
+            ;;
+        qemu)
+            printf '%s\n' 'vmm/sandbox/config_qemu_x86_64.toml'
+            ;;
+        stratovirt)
+            printf '%s\n' 'vmm/sandbox/config_stratovirt_x86_64.toml'
+            ;;
+        *)
+            die "unsupported hypervisor: ${HYPERVISOR}"
+            ;;
+    esac
+}
+
+install_crictl() {
+    local version="$1"
+    local tarball="crictl-${version}-linux-amd64.tar.gz"
+    curl -fsSL -o "/tmp/${tarball}" \
+        "https://github.com/kubernetes-sigs/cri-tools/releases/download/${version}/${tarball}"
+    sudo tar -C /usr/local/bin -xzf "/tmp/${tarball}"
+    rm -f "/tmp/${tarball}"
+}
+
+install_cni_plugins() {
+    local version="$1"
+    local tarball="cni-plugins-linux-amd64-${version}.tgz"
+    curl -fsSL -o "/tmp/${tarball}" \
+        "https://github.com/containernetworking/plugins/releases/download/${version}/${tarball}"
+    sudo mkdir -p /opt/cni/bin
+    sudo tar -C /opt/cni/bin -xzf "/tmp/${tarball}"
+    rm -f "/tmp/${tarball}"
+}
+
+install_cloud_hypervisor() {
+    local version="$1"
+    curl -fsSL -o /tmp/cloud-hypervisor-static \
+        "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${version}/cloud-hypervisor-static"
+    sudo install -m 0755 /tmp/cloud-hypervisor-static /usr/local/bin/cloud-hypervisor
+    rm -f /tmp/cloud-hypervisor-static
+}
+
+ensure_virtiofsd() {
+    if command -v virtiofsd >/dev/null 2>&1; then
+        sudo ln -sf "$(command -v virtiofsd)" /usr/local/bin/virtiofsd
+        return
+    fi
+
+    if [[ -x /usr/lib/qemu/virtiofsd ]]; then
+        sudo ln -sf /usr/lib/qemu/virtiofsd /usr/local/bin/virtiofsd
+        return
+    fi
+
+    if [[ -x /usr/libexec/virtiofsd ]]; then
+        sudo ln -sf /usr/libexec/virtiofsd /usr/local/bin/virtiofsd
+        return
+    fi
+
+    die "virtiofsd not found after dependency installation"
+}
+
+load_vhost_mods() {
+    sudo modprobe vhost
+    sudo modprobe vhost_net
+    sudo modprobe vhost_vsock
+}
+
+install_dependencies() {
+    log "Installing dependencies for ${HYPERVISOR}"
+
+    sudo apt-get update
+    sudo apt-get install -y \
+        build-essential \
+        curl \
+        git \
+        jq \
+        pkg-config \
+        libseccomp-dev \
+        protobuf-compiler \
+        iptables \
+        qemu-system-common \
+        qemu-utils \
+        iproute2 \
+        util-linux \
+        runc \
+        virtiofsd
+
+    install_crictl "${CRICTL_VERSION}"
+    install_cni_plugins "${CNI_PLUGINS_VERSION}"
+    install_cloud_hypervisor "${CLOUD_HYPERVISOR_VERSION}"
+    ensure_virtiofsd
+    load_vhost_mods
+}
+
+install_kuasar() {
+    local artifacts_path="${1:-${KUASAR_ARTIFACTS_DIR}}"
+    local config_relpath
+
+    config_relpath="$(resolve_hypervisor_config)"
+
+    log "Installing Kuasar artifacts from ${artifacts_path}"
+
+    [[ -f "${artifacts_path}/bin/containerd" ]] || die "missing ${artifacts_path}/bin/containerd"
+    [[ -f "${artifacts_path}/bin/config.toml" ]] || die "missing ${artifacts_path}/bin/config.toml"
+    [[ -f "${artifacts_path}/bin/vmm-sandboxer" ]] || die "missing ${artifacts_path}/bin/vmm-sandboxer"
+    [[ -f "${artifacts_path}/bin/vmlinux.bin" ]] || die "missing ${artifacts_path}/bin/vmlinux.bin"
+    [[ -f "${artifacts_path}/bin/kuasar.img" ]] || die "missing ${artifacts_path}/bin/kuasar.img"
+    [[ -f "${artifacts_path}/bin/kuasar-ctl" ]] || die "missing ${artifacts_path}/bin/kuasar-ctl"
+    [[ -f "${artifacts_path}/${config_relpath}" ]] || die "missing ${artifacts_path}/${config_relpath}"
+
+    sudo install -d -m 0755 /usr/local/bin /etc/containerd /var/lib/kuasar
+    sudo install -m 0755 "${artifacts_path}/bin/containerd" /usr/local/bin/containerd
+    sudo install -m 0755 "${artifacts_path}/bin/vmm-sandboxer" /usr/local/bin/vmm-sandboxer
+    sudo install -m 0644 "${artifacts_path}/bin/config.toml" /etc/containerd/config.toml
+    sudo install -m 0644 "${artifacts_path}/bin/vmlinux.bin" /var/lib/kuasar/vmlinux.bin
+    sudo install -m 0644 "${artifacts_path}/bin/kuasar.img" /var/lib/kuasar/kuasar.img
+    sudo install -m 0755 "${artifacts_path}/bin/kuasar-ctl" /usr/local/bin/kuasar-ctl
+    sudo install -m 0644 "${artifacts_path}/${config_relpath}" /var/lib/kuasar/config.toml
+
+    # Enable the guest debug console explicitly for kuasar-ctl.
+    if sudo grep -q '^kernel_params = ""' /var/lib/kuasar/config.toml; then
+        sudo sed -i 's/^kernel_params = ""$/kernel_params = "task.debug"/' \
+            /var/lib/kuasar/config.toml
+    elif ! sudo grep -q 'kernel_params = ".*task\.debug' /var/lib/kuasar/config.toml; then
+        sudo sed -i 's/^kernel_params = "\(.*\)"$/kernel_params = "\1 task.debug"/' \
+            /var/lib/kuasar/config.toml
+    fi
+}
+
+run_tests() {
+    log "Running cri-containerd tests using ${HYPERVISOR}"
+    bash "${script_dir}/integration-tests.sh"
+}
+
+main() {
+    local action="${1:-}"
+    case "${action}" in
+        install-dependencies) install_dependencies ;;
+        install-kuasar) install_kuasar "${2:-${KUASAR_ARTIFACTS_DIR}}" ;;
+        run) run_tests ;;
+        *) die "invalid action: ${action}" ;;
+    esac
+}
+
+main "$@"

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -1,0 +1,607 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly repo_root="$(cd "${script_dir}/../../.." && pwd -P)"
+readonly report_dir="$(mktemp -d -t kuasar-cri-containerd.XXXX)"
+
+export HYPERVISOR="${HYPERVISOR:-clh}"
+export RUNTIME_HANDLER="${RUNTIME_HANDLER:-kuasar-vmm}"
+export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${repo_root}/_artifacts/vmm-${HYPERVISOR}-cri-containerd}"
+export TEST_FILTER="${TEST_FILTER:-}"
+
+readonly containerd_log="${ARTIFACTS_DIR}/containerd.log"
+readonly vmm_log="${ARTIFACTS_DIR}/vmm-sandboxer.log"
+readonly cloud_hypervisor_ps="${ARTIFACTS_DIR}/cloud-hypervisor.ps.txt"
+readonly crictl_info="${ARTIFACTS_DIR}/crictl-info.txt"
+readonly crictl_pods="${ARTIFACTS_DIR}/crictl-pods.txt"
+readonly crictl_ps="${ARTIFACTS_DIR}/crictl-ps.txt"
+readonly sandbox_inspect="${ARTIFACTS_DIR}/sandbox-inspect.json"
+readonly container_inspect="${ARTIFACTS_DIR}/container-inspect.json"
+readonly config_snapshot="${ARTIFACTS_DIR}/config.toml"
+readonly exec_output_file="${ARTIFACTS_DIR}/exec-output.txt"
+readonly kuasar_ctl_output_file="${ARTIFACTS_DIR}/kuasar-ctl-output.txt"
+readonly task_logs_dir="${ARTIFACTS_DIR}/task-logs"
+
+readonly containerd_pid_file="${ARTIFACTS_DIR}/containerd.pid"
+readonly vmm_pid_file="${ARTIFACTS_DIR}/vmm-sandboxer.pid"
+readonly cni_config_file="/etc/cni/net.d/10-kuasar.conflist"
+readonly crictl_config_file="/etc/crictl.yaml"
+readonly kuasar_config_file="/var/lib/kuasar/config.toml"
+readonly vmm_socket="/run/vmm-sandboxer.sock"
+readonly tap_file="${ARTIFACTS_DIR}/results.tap"
+
+pod_id=""
+container_id=""
+test_failures=()
+error_reported=0
+extra_pod_ids=()
+tap_count=0
+
+log() {
+    printf '[cri-containerd] %s\n' "$*"
+}
+
+die() {
+    printf '[cri-containerd] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+dump_recent_logs() {
+    local task_logs=()
+    local primary_task_log=""
+    local task_log=""
+
+    echo '::group::containerd log (last 100 lines)'
+    if [[ -f "${containerd_log}" ]]; then
+        tail -n 100 "${containerd_log}" || true
+    else
+        printf '[cri-containerd] containerd log not found: %s\n' "${containerd_log}"
+    fi
+    echo '::endgroup::'
+
+    echo '::group::vmm-sandboxer log (last 200 lines)'
+    if [[ -f "${vmm_log}" ]]; then
+        tail -n 200 "${vmm_log}" || true
+    else
+        printf '[cri-containerd] vmm-sandboxer log not found: %s\n' "${vmm_log}"
+    fi
+    echo '::endgroup::'
+
+    if [[ -n "${pod_id}" ]]; then
+        primary_task_log="/tmp/${pod_id}-task.log"
+    fi
+
+    echo "::group::vmm-task logs (last 200 lines)"
+    if [[ -n "${primary_task_log}" ]] && [[ -f "${primary_task_log}" ]]; then
+        printf '[cri-containerd] tailing primary task log: %s\n' "${primary_task_log}"
+        tail -n 200 "${primary_task_log}" || true
+    fi
+
+    mapfile -t task_logs < <(compgen -G '/tmp/*-task.log' | sort || true)
+    if [[ ${#task_logs[@]} -eq 0 ]]; then
+        printf '[cri-containerd] no vmm-task log found under /tmp\n'
+    fi
+
+    for task_log in "${task_logs[@]}"; do
+        if [[ -n "${primary_task_log}" ]] && [[ "${task_log}" == "${primary_task_log}" ]]; then
+            continue
+        fi
+        printf '[cri-containerd] tailing fallback task log: %s\n' "${task_log}"
+        tail -n 200 "${task_log}" || true
+    done
+    echo '::endgroup::'
+}
+
+report_failure() {
+    local exit_code="${1:-1}"
+
+    if [[ "${error_reported}" -eq 1 ]]; then
+        return
+    fi
+    error_reported=1
+
+    dump_recent_logs
+    log "command failed with exit code ${exit_code}"
+}
+
+get_matching_pids() {
+    local process_name="$1"
+
+    pgrep -x "${process_name}" 2>/dev/null | sort || true
+}
+
+wait_for_file() {
+    local target="$1"
+    local retries="${2:-30}"
+    local delay="${3:-1}"
+
+    for _ in $(seq 1 "${retries}"); do
+        if [[ -e "${target}" ]]; then
+            return 0
+        fi
+        sleep "${delay}"
+    done
+
+    return 1
+}
+
+wait_for_container_state() {
+    local retries="${1:-30}"
+    local delay="${2:-2}"
+
+    for _ in $(seq 1 "${retries}"); do
+        local state
+        state="$(sudo crictl inspect "${container_id}" 2>/dev/null | jq -r '.status.state // empty' || true)"
+        if [[ "${state}" == "CONTAINER_RUNNING" ]]; then
+            return 0
+        fi
+        sleep "${delay}"
+    done
+
+    return 1
+}
+
+create_container_config() {
+    local container_config="$1"
+    local name="${2:-kuasar-vmm-busybox}"
+    local log_path="${3:-busybox.log}"
+
+    cat >"${container_config}" <<EOF
+{
+  "metadata": {
+    "name": "${name}",
+    "namespace": "default"
+  },
+  "image": {
+    "image": "docker.io/library/busybox:1.36.1"
+  },
+  "command": [
+    "/bin/sh",
+    "-c",
+    "sleep 3600"
+  ],
+  "log_path": "${log_path}",
+  "linux": {
+    "security_context": {
+      "namespace_options": {
+        "network": 2,
+        "pid": 1
+      }
+    }
+  }
+}
+EOF
+}
+
+create_podsandbox_config() {
+    local pod_config="$1"
+    local name="${2:-kuasar-vmm-clh-sandbox}"
+    local uid="${3:-kuasar-vmm-clh-sandbox-uid}"
+
+    cat >"${pod_config}" <<EOF
+{
+  "metadata": {
+    "name": "${name}",
+    "namespace": "default",
+    "uid": "${uid}"
+  },
+  "log_directory": "/tmp",
+  "linux": {
+    "security_context": {
+      "namespace_options": {
+        "network": 2,
+        "pid": 1
+      }
+    }
+  }
+}
+EOF
+}
+
+write_crictl_config() {
+    sudo tee "${crictl_config_file}" >/dev/null <<'EOF'
+runtime-endpoint: "unix:///run/containerd/containerd.sock"
+image-endpoint: "unix:///run/containerd/containerd.sock"
+timeout: 60
+debug: false
+pull-image-on-create: true
+EOF
+}
+
+write_cni_config() {
+    sudo mkdir -p "$(dirname "${cni_config_file}")"
+    sudo tee "${cni_config_file}" >/dev/null <<'EOF'
+{
+  "cniVersion": "0.4.0",
+  "name": "kuasar-test",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [
+            {
+              "subnet": "10.88.0.0/16"
+            }
+          ]
+        ],
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    }
+  ]
+}
+EOF
+}
+
+start_containerd() {
+    sudo rm -f /run/containerd/containerd.sock || true
+    sudo mkdir -p /run/containerd
+    sudo bash -c "ENABLE_CRI_SANDBOXES=1 /usr/local/bin/containerd --config /etc/containerd/config.toml > '${containerd_log}' 2>&1 & echo \$! > '${containerd_pid_file}'"
+
+    wait_for_file /run/containerd/containerd.sock 60 1 || die "containerd socket did not appear"
+}
+
+start_vmm_sandboxer() {
+    sudo rm -f "${vmm_socket}" || true
+    sudo mkdir -p /run/kuasar-vmm
+    # Pass the installed config path explicitly so CI does not rely on the
+    # sandboxer's default config resolution behavior.
+    sudo bash -c "/usr/local/bin/vmm-sandboxer --config ${kuasar_config_file} --listen ${vmm_socket} --dir /run/kuasar-vmm > '${vmm_log}' 2>&1 & echo \$! > '${vmm_pid_file}'"
+
+    wait_for_file "${vmm_socket}" 60 1 || die "vmm-sandboxer socket did not appear"
+}
+
+collect_state() {
+    local task_logs=()
+
+    sudo crictl info >"${crictl_info}" 2>&1 || true
+    sudo crictl pods >"${crictl_pods}" 2>&1 || true
+    sudo crictl ps -a >"${crictl_ps}" 2>&1 || true
+
+    if [[ -n "${pod_id}" ]]; then
+        sudo crictl inspectp "${pod_id}" >"${sandbox_inspect}" 2>&1 || true
+    fi
+
+    if [[ -n "${container_id}" ]]; then
+        sudo crictl inspect "${container_id}" >"${container_inspect}" 2>&1 || true
+    fi
+
+    pgrep -af cloud-hypervisor >"${cloud_hypervisor_ps}" 2>&1 || true
+    sudo cp /etc/containerd/config.toml "${config_snapshot}" 2>/dev/null || true
+
+    mkdir -p "${task_logs_dir}"
+    mapfile -t task_logs < <(compgen -G '/tmp/*-task.log' | sort || true)
+    for task_log in "${task_logs[@]}"; do
+        cp "${task_log}" "${task_logs_dir}/$(basename "${task_log}")" 2>/dev/null || true
+    done
+}
+
+cleanup() {
+    set +e
+    local extra_pod_id
+
+    collect_state
+
+    if [[ -n "${container_id}" ]]; then
+        sudo crictl rm -f "${container_id}" >/dev/null 2>&1 || true
+    fi
+
+    if [[ -n "${pod_id}" ]]; then
+        sudo crictl stopp "${pod_id}" >/dev/null 2>&1 || true
+        sudo crictl rmp -f "${pod_id}" >/dev/null 2>&1 || true
+    fi
+
+    for extra_pod_id in "${extra_pod_ids[@]}"; do
+        sudo crictl stopp "${extra_pod_id}" >/dev/null 2>&1 || true
+        sudo crictl rmp -f "${extra_pod_id}" >/dev/null 2>&1 || true
+    done
+
+    if [[ -f "${vmm_pid_file}" ]]; then
+        sudo kill "$(cat "${vmm_pid_file}")" >/dev/null 2>&1 || true
+    fi
+
+    if [[ -f "${containerd_pid_file}" ]]; then
+        sudo kill "$(cat "${containerd_pid_file}")" >/dev/null 2>&1 || true
+    fi
+
+    rm -rf "${report_dir}" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+trap 'report_failure $?' ERR
+
+setup_sandbox() {
+    local pod_config="${report_dir}/podsandbox.json"
+    local container_config="${report_dir}/container.json"
+
+    log "Setting up shared sandbox fixture"
+    create_podsandbox_config "${pod_config}"
+    create_container_config "${container_config}"
+
+    sudo crictl pull docker.io/library/busybox:1.36.1
+
+    pod_id="$(sudo crictl runp --runtime="${RUNTIME_HANDLER}" "${pod_config}")"
+    container_id="$(sudo crictl create "${pod_id}" "${container_config}" "${pod_config}")"
+    sudo crictl start "${container_id}"
+
+    wait_for_container_state 30 2 || die "container did not enter running state"
+
+    log "Verifying Cloud Hypervisor instance"
+    local clh_cmdline
+    clh_cmdline="$(pgrep -af cloud-hypervisor 2>/dev/null || true)"
+    [[ -n "${clh_cmdline}" ]] || die "cloud-hypervisor process not found"
+    echo "${clh_cmdline}" | grep -q "/var/lib/kuasar/vmlinux.bin" || die "cloud-hypervisor command line missing kernel path"
+    echo "${clh_cmdline}" | grep -q "/var/lib/kuasar/kuasar.img" || die "cloud-hypervisor command line missing image path"
+}
+
+test_multi_container_pod() {
+    local container2_config="${report_dir}/container2.json"
+    local container2_id
+    local output
+
+    log "Adding second container to shared sandbox"
+    create_container_config "${container2_config}" "kuasar-vmm-busybox-2" "busybox-2.log"
+
+    container2_id="$(sudo crictl create "${pod_id}" "${container2_config}" "${report_dir}/podsandbox.json")"
+    sudo crictl start "${container2_id}"
+
+    # Verify both can exec
+    output="$(sudo crictl exec "${container_id}" /bin/sh -c 'echo c1-ok')"
+    [[ "${output}" == "c1-ok" ]] || die "container 1 exec failed in multi-container pod"
+
+    output="$(sudo crictl exec "${container2_id}" /bin/sh -c 'echo c2-ok')"
+    [[ "${output}" == "c2-ok" ]] || die "container 2 exec failed in multi-container pod"
+
+    # Cleanup the second container
+    sudo crictl rm -f "${container2_id}"
+}
+
+test_cri_pod_lifecycle() {
+    local pod_cfg="${report_dir}/lifecycle-pod.json"
+    local p_id
+    local state
+
+    # Create a separate pod for lifecycle test
+    create_podsandbox_config "${pod_cfg}" "lifecycle-test-pod" "lifecycle-uid"
+
+    log "Testing Pod creation"
+    p_id="$(sudo crictl runp --runtime="${RUNTIME_HANDLER}" "${pod_cfg}")"
+    [[ -n "${p_id}" ]] || die "failed to run pod"
+    extra_pod_ids+=("${p_id}")
+
+    # Verify Ready
+    state="$(sudo crictl inspectp "${p_id}" | jq -r '.status.state')"
+    [[ "${state}" == "SANDBOX_READY" ]] || die "expected pod to be READY, got ${state}"
+
+    log "Testing Pod stopping"
+    sudo crictl stopp "${p_id}"
+    state="$(sudo crictl inspectp "${p_id}" | jq -r '.status.state')"
+    [[ "${state}" == "SANDBOX_NOTREADY" ]] || die "expected pod to be NOTREADY, got ${state}"
+
+    log "Testing Pod removal"
+    sudo crictl rmp -f "${p_id}"
+    if sudo crictl inspectp "${p_id}" >/dev/null 2>&1; then
+        die "pod ${p_id} still exists after rmp"
+    fi
+    extra_pod_ids=("${extra_pod_ids[@]/$p_id/}")
+}
+
+test_exec_smoke() {
+    local exec_output
+
+    set +e
+    exec_output="$(sudo crictl exec "${container_id}" /bin/sh -c 'echo kuasar-e2e-ok' 2>&1)"
+    local exec_rc=$?
+    set -e
+
+    printf '%s\n' "${exec_output}" >"${exec_output_file}"
+    [[ ${exec_rc} -eq 0 ]] || die "crictl exec failed: ${exec_output}"
+    grep -q "kuasar-e2e-ok" "${exec_output_file}" || die "unexpected exec output: ${exec_output}"
+}
+
+test_kuasar_ctl_exec() {
+    local output
+
+    # Use prefix of pod_id for resolution check
+    output="$(sudo kuasar-ctl exec "${pod_id:0:12}" -- sh -c 'echo kuasar-ctl-ok')"
+    printf '%s\n' "${output}" >"${kuasar_ctl_output_file}"
+    grep -q "kuasar-ctl-ok" <<< "${output}" || die "kuasar-ctl exec output mismatch: ${output}"
+}
+
+test_kuasar_ctl_exit_code() {
+    local rc=0
+    set +e
+    sudo kuasar-ctl exec "${pod_id:0:12}" -- sh -c 'exit 42'
+    rc=$?
+    set -e
+    [[ ${rc} -eq 42 ]] || die "kuasar-ctl exit code passthrough failed: got ${rc}, want 42"
+}
+
+test_kuasar_ctl_timeout() {
+    local rc=0
+    set +e
+    sudo kuasar-ctl exec "${pod_id:0:12}" --timeout 2 -- sh -c 'cat'
+    rc=$?
+    set -e
+    [[ ${rc} -eq 124 ]] || die "kuasar-ctl timeout exit code mismatch: got ${rc}, want 124"
+}
+
+test_kuasar_ctl_no_fd_leak() {
+    local vmm_pid clh_pid
+    vmm_pid=$(cat "${vmm_pid_file}")
+    clh_pid=$(pgrep cloud-hypervisor | head -1)
+
+    # warmup: exclude initial connection setup
+    sudo kuasar-ctl exec "${pod_id:0:12}" -- sh -c 'echo warmup' > /dev/null
+
+    local vmm_fd_before clh_fd_before
+    vmm_fd_before=$(sudo ls /proc/"${vmm_pid}"/fd 2>/dev/null | wc -l)
+    clh_fd_before=$(sudo ls /proc/"${clh_pid}"/fd 2>/dev/null | wc -l)
+
+    for i in $(seq 1 100); do
+        sudo kuasar-ctl exec "${pod_id:0:12}" -- sh -c "echo fd-leak-test-${i}" > /dev/null &
+    done
+    wait
+    sleep 1
+
+    local vmm_fd_after clh_fd_after
+    vmm_fd_after=$(sudo ls /proc/"${vmm_pid}"/fd 2>/dev/null | wc -l)
+    clh_fd_after=$(sudo ls /proc/"${clh_pid}"/fd 2>/dev/null | wc -l)
+
+    local vmm_diff clh_diff
+    vmm_diff=$(( vmm_fd_after - vmm_fd_before ))
+    clh_diff=$(( clh_fd_after - clh_fd_before ))
+
+    # Allow small fluctuations but not linear growth
+    [[ ${vmm_diff} -le 5 ]] || die "vmm-sandboxer fd leak: before=${vmm_fd_before} after=${vmm_fd_after} diff=${vmm_diff}"
+    [[ ${clh_diff} -le 5 ]] || die "cloud-hypervisor fd leak: before=${clh_fd_before} after=${clh_fd_after} diff=${clh_diff}"
+}
+
+test_kuasar_ctl_no_proc_leak() {
+    local pids_before
+    local pids_after
+    local lingering
+
+    pids_before="$(get_matching_pids kuasar-ctl)"
+
+    for i in $(seq 1 100); do
+        sudo kuasar-ctl exec "${pod_id:0:12}" -- sh -c "echo proc-leak-test-${i}" > /dev/null &
+    done
+    wait
+
+    sleep 1
+    pids_after="$(get_matching_pids kuasar-ctl)"
+    if [[ "${pids_before}" != "${pids_after}" ]]; then
+        lingering="$(comm -13 <(printf '%s\n' "${pids_before}") <(printf '%s\n' "${pids_after}") | tr '\n' ' ')"
+        die "lingering kuasar-ctl processes detected: ${lingering}"
+    fi
+
+    local zombies
+    zombies=$(ps -o stat= --ppid $$ | grep -c '^Z' || true)
+    [[ "${zombies}" -eq 0 ]] || die "zombie child processes detected for test shell: ${zombies}"
+}
+
+test_vmm_killed_cleanup() {
+    local p_config="${report_dir}/kill-vmm-pod.json"
+    local p_id
+    local clh_pid
+
+    log "Testing VMM killed cleanup"
+    create_podsandbox_config "${p_config}" "kill-vmm-pod" "kill-vmm-uid"
+    p_id="$(sudo crictl runp --runtime="${RUNTIME_HANDLER}" "${p_config}")"
+    extra_pod_ids+=("${p_id}")
+
+    # Find the CLH process for *this* pod by matching its sandbox directory
+    # in the command line (e.g., /run/kuasar-vmm/<pod_id_prefix>/...).
+    clh_pid=$(pgrep -f "cloud-hypervisor.*${p_id:0:12}" || true)
+    [[ -n "${clh_pid}" ]] || die "could not find cloud-hypervisor process for pod ${p_id}"
+
+    log "Killing Cloud Hypervisor (PID: ${clh_pid}) for Pod ${p_id}"
+    sudo kill -9 "${clh_pid}"
+
+    # Wait for vmm-sandboxer/containerd to realize the VMM is gone
+    sleep 5
+
+    # Attempt to stop and remove. It should not hang.
+    sudo crictl stopp "${p_id}" >/dev/null 2>&1 || true
+    sudo crictl rmp -f "${p_id}" >/dev/null 2>&1 || true
+
+    # Clean from tracker
+    extra_pod_ids=("${extra_pod_ids[@]/$p_id/}")
+
+    # Validate that no shim or clh process is left for this pod
+    if pgrep -f "${p_id}" >/dev/null 2>&1; then
+        die "processes for pod ${p_id} still lingering after VMM killed"
+    fi
+}
+
+run_test_group() {
+    local group_name="$1"
+    shift
+    local tests=("$@")
+
+    log ">>> Starting test group: ${group_name}"
+    for test_name in "${tests[@]}"; do
+        run_test_case "${test_name}"
+    done
+    log "<<< Finished test group: ${group_name}"
+}
+
+run_test_case() {
+    local test_name="$1"
+
+    if [[ -n "${TEST_FILTER}" ]] && [[ "${test_name}" != *"${TEST_FILTER}"* ]]; then
+        return 0
+    fi
+
+    tap_count=$((tap_count + 1))
+    log "Running ${test_name}"
+    if "${test_name}"; then
+        log "${test_name} passed"
+        printf 'ok %d - %s\n' "${tap_count}" "${test_name}" | tee -a "${tap_file}"
+        return 0
+    fi
+
+    log "${test_name} FAILED — dumping logs"
+    printf 'not ok %d - %s\n' "${tap_count}" "${test_name}" | tee -a "${tap_file}"
+    dump_recent_logs
+    test_failures+=("${test_name}")
+    return 1
+}
+
+run_all_tests() {
+    run_test_group "CRI Basic" \
+        test_cri_pod_lifecycle \
+        test_multi_container_pod \
+        test_exec_smoke
+
+    run_test_group "kuasar-ctl Functionality" \
+        test_kuasar_ctl_exec \
+        test_kuasar_ctl_exit_code \
+        test_kuasar_ctl_timeout
+
+    run_test_group "kuasar-ctl Stability (Stress)" \
+        test_kuasar_ctl_no_fd_leak \
+        test_kuasar_ctl_no_proc_leak \
+        test_vmm_killed_cleanup
+
+    if [[ ${#test_failures[@]} -ne 0 ]]; then
+        echo "1..${tap_count}" >> "${tap_file}"
+        die "CRI tests failed: ${test_failures[*]}"
+    fi
+    echo "1..${tap_count}" >> "${tap_file}"
+}
+
+main() {
+    mkdir -p "${ARTIFACTS_DIR}"
+    echo "TAP version 13" > "${tap_file}"
+    write_crictl_config
+    write_cni_config
+    start_containerd
+    start_vmm_sandboxer
+    setup_sandbox
+    run_all_tests
+    collect_state
+    log "CRI tests passed for ${HYPERVISOR}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add `cri-containerd` integration checks to the Kuasar VMM CI workflow.

This PR adds a dedicated CI path that builds the Kuasar containerd fork together
with reusable VMM artifacts, restores cached outputs when possible, and runs the
Cloud Hypervisor based `cri-containerd` integration suite through shared shell
entry points.

## Coverage

The new suite covers:

- pod lifecycle through CRI
- multi-container pod behavior
- `crictl exec` smoke validation
- `kuasar-ctl exec`
    - exit code passthrough
    - timeout handling
    - repeated exec stress checks for fd/process leak detection
- cleanup after Cloud Hypervisor termination
