### PR TITLE
vmm/sandbox: retry atomic write if stale temp file exists

### DIFF
--- a/vmm/sandbox/src/utils.rs
+++ b/vmm/sandbox/src/utils.rs
@@ -342,39 +342,26 @@ pub async fn write_file_atomic<P: AsRef<Path>>(path: P, s: &str) -> Result<()> {
         .parent()
         .map(|x| x.join(format!(".{}", file.to_str().unwrap_or(""))))
         .ok_or_else(|| Error::InvalidArgument(String::from("failed to create tmp path")))?;
-    let tmp_path = tmp_path.to_str().ok_or_else(|| {
-        Error::InvalidArgument(format!("failed to get path: {}", tmp_path.display()))
-    })?;
-    let mut f = match OpenOptions::new()
+
+    // Using truncate(true) to handle existing stale files efficiently.
+    let mut f = OpenOptions::new()
         .write(true)
-        .create_new(true)
-        .open(tmp_path)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
         .await
-    {
-        Ok(file) => file,
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            // Atomic file writes may be retried after a previous attempt was interrupted,
-            // leaving the temporary file behind. Remove the stale temp file and retry once.
-            tokio::fs::remove_file(tmp_path)
-                .await
-                .map_err(|e| anyhow!("failed to remove stale temp path {}, {}", tmp_path, e))?;
-            OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(tmp_path)
-                .await
-                .map_err(|e| anyhow!("failed to open path {}, {}", tmp_path, e))?
-        }
-        Err(e) => {
-            return Err(anyhow!("failed to open path {}, {}", tmp_path, e).into());
-        }
-    };
-    f.write_all(s.as_bytes())
-        .await
-        .map_err(|e| anyhow!("failed to write string to path {}, {}", tmp_path, e))?;
+        .map_err(|e| anyhow!("failed to open path {}, {}", tmp_path.display(), e))?;
+
+    f.write_all(s.as_bytes()).await.map_err(|e| {
+        anyhow!(
+            "failed to write string to path {}, {}",
+            tmp_path.display(),
+            e
+        )
+    })?;
     f.sync_data()
         .await
-        .map_err(|e| anyhow!("failed to sync data to path {}, {}", tmp_path, e))?;
+        .map_err(|e| anyhow!("failed to sync data to path {}, {}", tmp_path.display(), e))?;
 
     tokio::fs::rename(tmp_path, path)
         .await

--- a/vmm/sandbox/src/utils.rs
+++ b/vmm/sandbox/src/utils.rs
@@ -345,12 +345,30 @@ pub async fn write_file_atomic<P: AsRef<Path>>(path: P, s: &str) -> Result<()> {
     let tmp_path = tmp_path.to_str().ok_or_else(|| {
         Error::InvalidArgument(format!("failed to get path: {}", tmp_path.display()))
     })?;
-    let mut f = OpenOptions::new()
+    let mut f = match OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(tmp_path)
         .await
-        .map_err(|e| anyhow!("failed to open path {}, {}", tmp_path, e))?;
+    {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Atomic file writes may be retried after a previous attempt was interrupted,
+            // leaving the temporary file behind. Remove the stale temp file and retry once.
+            tokio::fs::remove_file(tmp_path)
+                .await
+                .map_err(|e| anyhow!("failed to remove stale temp path {}, {}", tmp_path, e))?;
+            OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(tmp_path)
+                .await
+                .map_err(|e| anyhow!("failed to open path {}, {}", tmp_path, e))?
+        }
+        Err(e) => {
+            return Err(anyhow!("failed to open path {}, {}", tmp_path, e).into());
+        }
+    };
     f.write_all(s.as_bytes())
         .await
         .map_err(|e| anyhow!("failed to write string to path {}, {}", tmp_path, e))?;
@@ -525,5 +543,27 @@ pub fn start_watchdog() {
                 sleep(interval).await;
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use temp_dir::TempDir;
+
+    use super::write_file_atomic;
+
+    #[tokio::test]
+    async fn test_write_file_atomic_retries_when_stale_temp_exists() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.child("io-file");
+        let tmp_path = dir.child(".io-file");
+
+        tokio::fs::write(&tmp_path, "stale").await.unwrap();
+
+        write_file_atomic(&path, "fresh").await.unwrap();
+
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(content, "fresh");
+        assert!(!tmp_path.exists());
     }
 }


### PR DESCRIPTION
When writing files atomically, a temporary file is created with a leading dot and then renamed to the target path. If a previous attempt was interrupted (e.g., during pod liveness probe exec), this temporary file might already exist, causing an "AlreadyExists" (os error 17) error.
```
Liveness probe errored and resulted in unknown state: rpc error: code = Internal desc = failed to exec in container: failed to create exec "33e80ecf5f87195cc3c6f0cdc700209d934fbad46ba2adc986744af2b2a2c78c": failed to open path /run/kuasar-vmm/7e49999796186488c0a7817bee944357354939e785af41420444e7417f280f35/shared/0fd694ec7fb406b15bfcba14d4061e71ic34a0e67f96c8f6104bd66c807a8b7c9/.io-0fd694ec7fb406b15bfcba14d4061e71ic34a0e67f96c8f6104bd66c807a8b7c9-73b1d02fe7eb5a535ff136e5bd9d789fb45569f1db563f81356c47a61775e212d, File exists (os error 17)
```
This patch adds a retry mechanism: if the temporary file exists, it removes the stale file and retries the creation once.
