### PR TITLE
vmm/sandbox: improve availability with concurrent recovery

### DIFF
--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -110,39 +110,46 @@ report_failure() {
 
 get_matching_pids() {
     local process_name="$1"
-
     pgrep -x "${process_name}" 2>/dev/null | sort || true
+}
+
+get_clh_pid_by_sandbox_id() {
+    local sandbox_id="$1"
+    pgrep -f "cloud-hypervisor.*${sandbox_id:0:12}" 2>/dev/null | head -1 || true
+}
+
+wait_for_condition() {
+    local retries="${1:-150}"
+    local delay="${2:-0.2}"
+    shift 2
+
+    for _ in $(seq 1 "${retries}"); do
+        if eval "$*"; then
+            return 0
+        fi
+        sleep "${delay}"
+    done
+
+    return 1
 }
 
 wait_for_file() {
     local target="$1"
-    local retries="${2:-30}"
-    local delay="${3:-1}"
+    wait_for_condition "${2:-150}" "${3:-0.2}" "test -e \"${target}\""
+}
 
-    for _ in $(seq 1 "${retries}"); do
-        if [[ -e "${target}" ]]; then
-            return 0
-        fi
-        sleep "${delay}"
-    done
+wait_for_pid_exit() {
+    local pid="$1"
+    wait_for_condition "${2:-150}" "${3:-0.2}" "! sudo kill -0 \"${pid}\" >/dev/null 2>&1"
+}
 
-    return 1
+wait_for_pid_stop() {
+    local pid="$1"
+    wait_for_condition "${2:-150}" "${3:-0.2}" "ps -o stat= -p \"${pid}\" 2>/dev/null | grep -Eq '^[Tt]'"
 }
 
 wait_for_container_state() {
-    local retries="${1:-30}"
-    local delay="${2:-2}"
-
-    for _ in $(seq 1 "${retries}"); do
-        local state
-        state="$(sudo crictl inspect "${container_id}" 2>/dev/null | jq -r '.status.state // empty' || true)"
-        if [[ "${state}" == "CONTAINER_RUNNING" ]]; then
-            return 0
-        fi
-        sleep "${delay}"
-    done
-
-    return 1
+    wait_for_condition "${1:-150}" "${2:-0.2}" "[[ \"\$(sudo crictl inspect \"\${container_id}\" 2>/dev/null | jq -r '.status.state // empty' || true)\" == \"CONTAINER_RUNNING\" ]]"
 }
 
 create_container_config() {
@@ -253,21 +260,40 @@ EOF
 }
 
 start_containerd() {
+    if sudo crictl info >/dev/null 2>&1; then
+        return 0
+    fi
+
+    sudo pkill -9 containerd || true
     sudo rm -f /run/containerd/containerd.sock || true
     sudo mkdir -p /run/containerd
     sudo bash -c "ENABLE_CRI_SANDBOXES=1 /usr/local/bin/containerd --config /etc/containerd/config.toml > '${containerd_log}' 2>&1 & echo \$! > '${containerd_pid_file}'"
 
-    wait_for_file /run/containerd/containerd.sock 60 1 || die "containerd socket did not appear"
+    wait_for_file /run/containerd/containerd.sock || die "containerd socket did not appear"
 }
 
 start_vmm_sandboxer() {
+    local retries="${1:-60}"
+
+    if [[ -S "${vmm_socket}" ]] && pkill -0 vmm-sandboxer 2>/dev/null; then
+        local pid
+        pid=$(pgrep -x vmm-sandboxer | head -n 1)
+        log "vmm-sandboxer is already running (PID: ${pid}), skipping start"
+        echo "${pid}" | sudo tee "${vmm_pid_file}" > /dev/null
+        return 0
+    fi
+
+    log "Starting vmm-sandboxer..."
+
+    sudo pkill -9 vmm-sandboxer || true
     sudo rm -f "${vmm_socket}" || true
     sudo mkdir -p /run/kuasar-vmm
     # Pass the installed config path explicitly so CI does not rely on the
     # sandboxer's default config resolution behavior.
-    sudo bash -c "/usr/local/bin/vmm-sandboxer --config ${kuasar_config_file} --listen ${vmm_socket} --dir /run/kuasar-vmm > '${vmm_log}' 2>&1 & echo \$! > '${vmm_pid_file}'"
+    sudo bash -c "/usr/local/bin/vmm-sandboxer --config ${kuasar_config_file} --listen ${vmm_socket} --dir /run/kuasar-vmm --log-level debug > '${vmm_log}' 2>&1 & echo \$! > '${vmm_pid_file}'"
 
-    wait_for_file "${vmm_socket}" 60 1 || die "vmm-sandboxer socket did not appear"
+    log "Waiting for vmm-sandboxer socket ${vmm_socket}..."
+    wait_for_file "${vmm_socket}" "${retries}" 1 || die "vmm-sandboxer socket did not appear"
 }
 
 collect_state() {
@@ -343,7 +369,7 @@ setup_sandbox() {
     container_id="$(sudo crictl create "${pod_id}" "${container_config}" "${pod_config}")"
     sudo crictl start "${container_id}"
 
-    wait_for_container_state 30 2 || die "container did not enter running state"
+    wait_for_container_state || die "container did not enter running state"
 
     log "Verifying Cloud Hypervisor instance"
     local clh_cmdline
@@ -405,7 +431,7 @@ test_cri_pod_lifecycle() {
     extra_pod_ids=("${extra_pod_ids[@]/$p_id/}")
 }
 
-test_exec_smoke() {
+test_exec() {
     local exec_output
 
     set +e
@@ -501,9 +527,7 @@ test_kuasar_ctl_no_proc_leak() {
 }
 
 test_vmm_killed_cleanup() {
-    local p_config="${report_dir}/kill-vmm-pod.json"
-    local p_id
-    local clh_pid
+    local p_config="${report_dir}/kill-vmm-pod.json" p_id clh_pid
 
     log "Testing VMM killed cleanup"
     create_podsandbox_config "${p_config}" "kill-vmm-pod" "kill-vmm-uid"
@@ -512,11 +536,12 @@ test_vmm_killed_cleanup() {
 
     # Find the CLH process for *this* pod by matching its sandbox directory
     # in the command line (e.g., /run/kuasar-vmm/<pod_id_prefix>/...).
-    clh_pid=$(pgrep -f "cloud-hypervisor.*${p_id:0:12}" || true)
+    clh_pid=$(get_clh_pid_by_sandbox_id "${p_id}")
     [[ -n "${clh_pid}" ]] || die "could not find cloud-hypervisor process for pod ${p_id}"
 
     log "Killing Cloud Hypervisor (PID: ${clh_pid}) for Pod ${p_id}"
     sudo kill -9 "${clh_pid}"
+    wait_for_pid_exit "${clh_pid}" || die "cloud-hypervisor ${clh_pid} did not exit"
 
     # Wait for vmm-sandboxer/containerd to realize the VMM is gone
     sleep 5
@@ -532,6 +557,62 @@ test_vmm_killed_cleanup() {
     if pgrep -f "${p_id}" >/dev/null 2>&1; then
         die "processes for pod ${p_id} still lingering after VMM killed"
     fi
+}
+
+test_vmm_stuck_recovery_cleanup() {
+    local pod_count=2 p_config old_vmm_pid restart_begin_s restart_elapsed_s i p_id clh_pid sandbox_dir
+    local -a p_ids=() clh_pids=() sandbox_dirs=()
+
+    log "Testing vmm-sandboxer stuck recovery with ${pod_count} frozen VMM pods"
+    for i in $(seq 1 "${pod_count}"); do
+        p_config="${report_dir}/kill-vmm-pod-${i}.json"
+        create_podsandbox_config "${p_config}" "kill-vmm-pod-${i}" "kill-vmm-uid-${i}"
+        p_id="$(sudo crictl runp --runtime="${RUNTIME_HANDLER}" "${p_config}")"
+        extra_pod_ids+=("${p_id}")
+        p_ids+=("${p_id}")
+        sandbox_dir="/run/kuasar-vmm/${p_id}"
+        sandbox_dirs+=("${sandbox_dir}")
+
+        # Find the CLH process for *this* pod by matching its sandbox directory
+        # in the command line (e.g., /run/kuasar-vmm/<pod_id_prefix>/...).
+        clh_pid=$(get_clh_pid_by_sandbox_id "${p_id}")
+        [[ -n "${clh_pid}" ]] || die "could not find cloud-hypervisor process for pod ${p_id}"
+        [[ -d "${sandbox_dir}" ]] || die "sandbox dir ${sandbox_dir} does not exist before restart"
+        clh_pids+=("${clh_pid}")
+    done
+
+    old_vmm_pid="$(cat "${vmm_pid_file}")"
+    log "Stopping vmm-sandboxer (PID: ${old_vmm_pid}) before injecting VMM fault"
+    sudo kill -9 "${old_vmm_pid}"
+    wait_for_pid_exit "${old_vmm_pid}" || die "vmm-sandboxer ${old_vmm_pid} did not exit"
+
+    for i in "${!clh_pids[@]}"; do
+        log "Freezing Cloud Hypervisor (PID: ${clh_pids[${i}]})"
+        sudo kill -STOP "${clh_pids[${i}]}"
+        wait_for_pid_stop "${clh_pids[${i}]}" || die "cloud-hypervisor ${clh_pids[${i}]} did not enter stopped state"
+    done
+
+    restart_begin_s="$(date +%s)"
+    start_vmm_sandboxer 15
+    restart_elapsed_s="$(( $(date +%s) - restart_begin_s ))"
+    [[ "${restart_elapsed_s}" -le 15 ]] || die "vmm-sandboxer restart exceeded 15s: ${restart_elapsed_s}s"
+
+    for i in "${!p_ids[@]}"; do
+        [[ ! -d "${sandbox_dirs[${i}]}" ]] || die "failed sandbox dir ${sandbox_dirs[${i}]} still exists after restart recovery"
+
+        sudo crictl stopp "${p_ids[${i}]}" >/dev/null 2>&1 || true
+        sudo crictl rmp -f "${p_ids[${i}]}" >/dev/null 2>&1 || true
+
+        if sudo crictl inspectp "${p_ids[${i}]}" >/dev/null 2>&1; then
+            die "pod ${p_ids[${i}]} still exists after cleanup"
+        fi
+
+        extra_pod_ids=("${extra_pod_ids[@]/${p_ids[${i}]}/}")
+
+        if pgrep -f "${p_ids[${i}]}" >/dev/null 2>&1; then
+            die "processes for pod ${p_ids[${i}]} still lingering after restart recovery"
+        fi
+    done
 }
 
 run_test_group() {
@@ -572,7 +653,7 @@ run_all_tests() {
     run_test_group "CRI Basic" \
         test_cri_pod_lifecycle \
         test_multi_container_pod \
-        test_exec_smoke
+        test_exec
 
     run_test_group "kuasar-ctl Functionality" \
         test_kuasar_ctl_exec \
@@ -581,8 +662,11 @@ run_all_tests() {
 
     run_test_group "kuasar-ctl Stability (Stress)" \
         test_kuasar_ctl_no_fd_leak \
-        test_kuasar_ctl_no_proc_leak \
-        test_vmm_killed_cleanup
+        test_kuasar_ctl_no_proc_leak
+
+    run_test_group "Sandbox Recovery & Cleanup" \
+        test_vmm_killed_cleanup \
+        test_vmm_stuck_recovery_cleanup
 
     if [[ ${#test_failures[@]} -ne 0 ]]; then
         echo "1..${tap_count}" >> "${tap_file}"

--- a/vmm/sandbox/src/client.rs
+++ b/vmm/sandbox/src/client.rs
@@ -53,13 +53,21 @@ use vmm_common::api::{
 };
 
 const HVSOCK_RETRY_TIMEOUT_IN_MS: u64 = 10;
+const FAST_FAIL_CONNECT_TIMEOUT_IN_SECS: u64 = 3;
 // TODO: reduce to 10s
 const NEW_TTRPC_CLIENT_TIMEOUT: u64 = 45;
+pub(crate) const DEFAULT_CLIENT_CHECK_TIMEOUT: u64 = 45;
 const TIME_SYNC_PERIOD: u64 = 60;
 const TIME_DIFF_TOLERANCE_IN_MS: u64 = 10;
 
 pub(crate) async fn new_sandbox_client(address: &str) -> Result<SandboxServiceClient> {
     let client = new_ttrpc_client_with_timeout(address, NEW_TTRPC_CLIENT_TIMEOUT).await?;
+    Ok(SandboxServiceClient::new(client))
+}
+
+pub(crate) async fn new_sandbox_client_fail_fast(address: &str) -> Result<SandboxServiceClient> {
+    let client =
+        new_ttrpc_client_with_fast_fail(address, FAST_FAIL_CONNECT_TIMEOUT_IN_SECS).await?;
     Ok(SandboxServiceClient::new(client))
 }
 
@@ -87,6 +95,50 @@ async fn new_ttrpc_client_with_timeout(address: &str, t: u64) -> Result<Client> 
         .await
         .map_err(|_| anyhow!("{}s timeout connecting socket: {}", t, last_err))?;
     Ok(client)
+}
+
+async fn new_ttrpc_client_with_fast_fail(address: &str, t: u64) -> Result<Client> {
+    let mut last_err = Error::Other(anyhow!(""));
+
+    let fut = async {
+        loop {
+            match connect_to_socket(address).await {
+                Ok(fd) => {
+                    let client = Client::new(fd);
+                    return Ok(client);
+                }
+                Err(e) => {
+                    if is_fatal_error(&e) {
+                        return Err(e);
+                    }
+                    last_err = e;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    };
+
+    let client = timeout(Duration::from_secs(t), fut)
+        .await
+        .map_err(|_| anyhow!("{}s timeout connecting socket: {}", t, last_err))??;
+    Ok(client)
+}
+
+fn is_fatal_error(e: &Error) -> bool {
+    let is_fatal_io_error = |err: &std::io::Error| {
+        matches!(
+            err.kind(),
+            std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+        )
+    };
+    match e {
+        Error::IO(err) => is_fatal_io_error(err),
+        Error::Other(err) => err
+            .chain()
+            .filter_map(|source| source.downcast_ref::<std::io::Error>())
+            .any(is_fatal_io_error),
+        _ => false,
+    }
 }
 
 // Supported sock address formats are:
@@ -217,15 +269,14 @@ pub fn unix_sock(r#abstract: bool, socket_path: &str) -> Result<UnixAddr> {
     Ok(sockaddr_u)
 }
 
-pub(crate) async fn client_check(client: &SandboxServiceClient) -> Result<()> {
+pub(crate) async fn client_check(client: &SandboxServiceClient, t_secs: u64) -> Result<()> {
     // the initial timeout is 1, and will grow exponentially
     let retry_timeout = 1;
-    let ctx_timeout = 45;
 
     let res_fut = do_check_agent(client, retry_timeout);
-    timeout(Duration::from_secs(ctx_timeout), res_fut)
+    timeout(Duration::from_secs(t_secs), res_fut)
         .await
-        .map_err(|_| anyhow!("{}s timeout checking", ctx_timeout))?;
+        .map_err(|_| anyhow!("{}s timeout checking", t_secs))?;
     Ok(())
 }
 
@@ -358,7 +409,15 @@ pub(crate) async fn publish_event(envelope: Envelope) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::client::{checked_compute_delta, new_ttrpc_client_with_timeout};
+    use std::io::ErrorKind;
+
+    use anyhow::anyhow;
+    use containerd_sandbox::error::Error;
+
+    use crate::client::{
+        checked_compute_delta, is_fatal_error, new_ttrpc_client_with_fast_fail,
+        new_ttrpc_client_with_timeout,
+    };
 
     #[tokio::test]
     async fn test_new_ttrpc_client_timeout() {
@@ -366,6 +425,41 @@ mod tests {
         assert!(new_ttrpc_client_with_timeout("hvsock://fake.sock:1024", 1)
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_new_ttrpc_client_fast_fail() {
+        let err = match new_ttrpc_client_with_fast_fail("hvsock://fake.sock:1024", 1).await {
+            Ok(_) => panic!("fast-fail path should return error"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("timeout")
+                || err.to_string().contains("failed to connect")
+                || err.to_string().contains("No such file"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_is_fatal_error_for_io_errors() {
+        let broken_pipe = Error::IO(std::io::Error::from(ErrorKind::BrokenPipe));
+        let connection_reset = Error::IO(std::io::Error::from(ErrorKind::ConnectionReset));
+        let not_found = Error::IO(std::io::Error::from(ErrorKind::NotFound));
+
+        assert!(is_fatal_error(&broken_pipe));
+        assert!(is_fatal_error(&connection_reset));
+        assert!(!is_fatal_error(&not_found));
+    }
+
+    #[test]
+    fn test_is_fatal_error_for_wrapped_io_errors() {
+        let wrapped_reset = Error::Other(anyhow!(std::io::Error::from(ErrorKind::ConnectionReset)));
+        let wrapped_permission =
+            Error::Other(anyhow!(std::io::Error::from(ErrorKind::PermissionDenied)));
+
+        assert!(is_fatal_error(&wrapped_reset));
+        assert!(!is_fatal_error(&wrapped_permission));
     }
 
     #[test]

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, io::ErrorKind, path::Path, sync::Arc};
+use std::{collections::HashMap, io::ErrorKind, path::Path, sync::Arc, time::Instant};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -33,7 +33,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::{
     fs::{copy, create_dir_all, remove_dir_all, OpenOptions},
     io::{AsyncReadExt, AsyncWriteExt},
-    sync::{Mutex, RwLock},
+    sync::{Mutex, RwLock, Semaphore},
 };
 use tracing::instrument;
 use ttrpc::context::with_timeout;
@@ -45,7 +45,10 @@ use vmm_common::{
 
 use crate::{
     cgroup::{SandboxCgroup, DEFAULT_CGROUP_PARENT_PATH},
-    client::{client_check, client_setup_sandbox, client_sync_clock, new_sandbox_client},
+    client::{
+        client_check, client_setup_sandbox, client_sync_clock, new_sandbox_client,
+        new_sandbox_client_fail_fast, DEFAULT_CLIENT_CHECK_TIMEOUT,
+    },
     container::KuasarContainer,
     network::{Network, NetworkConfig},
     utils::{get_dns_config, get_hostname, get_resources, get_sandbox_cgroup_parent_path},
@@ -87,6 +90,7 @@ where
 {
     #[instrument(skip_all)]
     pub async fn recover(&mut self, dir: &str) {
+        let start = Instant::now();
         let mut subs = match tokio::fs::read_dir(dir).await {
             Ok(subs) => subs,
             Err(e) => {
@@ -94,37 +98,82 @@ where
                 return;
             }
         };
+
+        let mut entries = Vec::new();
         while let Some(entry) = subs.next_entry().await.unwrap() {
+            entries.push(entry);
+        }
+
+        // Limit the concurrency of sandbox recovery.
+        // When a node has a large number of pods (e.g., 1k pods), unbounded concurrent
+        // recovery could consume massive system resources, potentially preempting and
+        // starving normal business workloads.
+        const RECOVERY_CONCURRENCY: usize = 32;
+        let semaphore = Arc::new(Semaphore::new(RECOVERY_CONCURRENCY));
+        let mut handles = Vec::with_capacity(entries.len());
+
+        for entry in entries {
             if let Ok(t) = entry.file_type().await {
                 if !t.is_dir() {
                     continue;
                 }
-                debug!("recovering sandbox {:?}", entry.file_name());
-                let path = Path::new(dir).join(entry.file_name());
-                match KuasarSandbox::recover(&path).await {
-                    Ok(sb) => {
-                        let status = sb.status.clone();
-                        let sb_mutex = Arc::new(Mutex::new(sb));
-                        // Only running sandbox should be monitored.
-                        if let SandboxStatus::Running(_) = status {
-                            let sb_clone = sb_mutex.clone();
-                            monitor(sb_clone);
+                let dir_path = dir.to_string();
+                let sandboxes = self.sandboxes.clone();
+                let permit = semaphore.clone().acquire_owned().await.unwrap();
+
+                let handle = tokio::spawn(async move {
+                    let _permit = permit;
+                    debug!("recovering sandbox {:?}", entry.file_name());
+                    let path = Path::new(&dir_path).join(entry.file_name());
+                    match KuasarSandbox::recover(&path).await {
+                        Ok(sb) => {
+                            let status = sb.status.clone();
+                            let sb_mutex = Arc::new(Mutex::new(sb));
+                            // Only running sandbox should be monitored.
+                            if let SandboxStatus::Running(_) = status {
+                                let sb_clone = sb_mutex.clone();
+                                monitor(sb_clone);
+                            }
+                            sandboxes
+                                .write()
+                                .await
+                                .insert(entry.file_name().to_str().unwrap().to_string(), sb_mutex);
+                            true
                         }
-                        self.sandboxes
-                            .write()
-                            .await
-                            .insert(entry.file_name().to_str().unwrap().to_string(), sb_mutex);
+                        Err(e) => {
+                            warn!("failed to recover sandbox {:?}, {:?}", entry.file_name(), e);
+                            cleanup_mounts(path.to_str().unwrap())
+                                .await
+                                .unwrap_or_default();
+                            remove_dir_all(&path).await.unwrap_or_default();
+                            false
+                        }
                     }
-                    Err(e) => {
-                        warn!("failed to recover sandbox {:?}, {:?}", entry.file_name(), e);
-                        cleanup_mounts(path.to_str().unwrap())
-                            .await
-                            .unwrap_or_default();
-                        remove_dir_all(&path).await.unwrap_or_default();
-                    }
+                });
+                handles.push(handle);
+            }
+        }
+
+        let total = handles.len();
+        let mut success = 0;
+        let mut fail = 0;
+        for handle in handles {
+            match handle.await {
+                Ok(true) => success += 1,
+                Ok(false) => fail += 1,
+                Err(e) => {
+                    error!("recovery task join error: {}", e);
+                    fail += 1;
                 }
             }
         }
+        info!(
+            "recover sandboxes finished, total: {}, success: {}, fail: {}, takes: {:.3}s",
+            total,
+            success,
+            fail,
+            start.elapsed().as_secs_f64()
+        );
     }
 }
 
@@ -439,6 +488,7 @@ where
 {
     #[instrument(skip_all)]
     async fn recover<P: AsRef<Path>>(base_dir: P) -> Result<Self> {
+        let start = Instant::now();
         let dump_path = base_dir.as_ref().join("sandbox.json");
         let mut dump_file = OpenOptions::new()
             .read(true)
@@ -461,7 +511,7 @@ where
                 }
                 return Err(e);
             };
-            if let Err(e) = sb.init_client().await {
+            if let Err(e) = sb.init_client_fail_fast().await {
                 if let Err(re) = sb.stop(true).await {
                     warn!("roll back in recover, init task client and stop: {}", re);
                     return Err(e);
@@ -475,6 +525,11 @@ where
         sb.sandbox_cgroups =
             SandboxCgroup::create_sandbox_cgroups(&sb.sandbox_cgroups.cgroup_parent_path, &sb.id)?;
 
+        info!(
+            "recover sandbox {} takes {}ms",
+            sb.id,
+            start.elapsed().as_millis()
+        );
         Ok(sb)
     }
 }
@@ -574,10 +629,36 @@ where
                 return Err(anyhow!("VM address is empty").into());
             }
             let client = new_sandbox_client(&addr).await?;
-            debug!("connected to task server {}", self.id);
-            client_check(&client).await?;
-            *client_guard = Some(client)
+            self.check_and_set_client(&mut client_guard, client).await?;
         }
+        Ok(())
+    }
+
+    /// Use fail-fast connect strategy during recovery: if the guest agent
+    /// socket returns a fatal error (e.g. broken pipe), bail out immediately
+    /// instead of retrying until timeout.
+    #[instrument(skip_all)]
+    async fn init_client_fail_fast(&mut self) -> Result<()> {
+        let mut client_guard = self.client.lock().await;
+        if client_guard.is_none() {
+            let addr = self.vm.socket_address();
+            if addr.is_empty() {
+                return Err(anyhow!("VM address is empty").into());
+            }
+            let client = new_sandbox_client_fail_fast(&addr).await?;
+            self.check_and_set_client(&mut client_guard, client).await?;
+        }
+        Ok(())
+    }
+
+    async fn check_and_set_client(
+        &self,
+        guard: &mut tokio::sync::MutexGuard<'_, Option<SandboxServiceClient>>,
+        client: SandboxServiceClient,
+    ) -> Result<()> {
+        debug!("connected to task server {}", self.id);
+        client_check(&client, DEFAULT_CLIENT_CHECK_TIMEOUT).await?;
+        **guard = Some(client);
         Ok(())
     }
 
@@ -900,6 +981,222 @@ fn monitor<V: VM + 'static>(sandbox_mutex: Arc<Mutex<KuasarSandbox<V>>>) {
 
 #[cfg(test)]
 mod tests {
+    mod recovery {
+        use std::{collections::HashMap, path::Path, sync::Arc};
+
+        use async_trait::async_trait;
+        use containerd_sandbox::{
+            data::SandboxData, error::Result, signal::ExitSignal, SandboxOption, SandboxStatus,
+        };
+        use serde::{Deserialize, Serialize};
+        use temp_dir::TempDir;
+        use tokio::sync::Mutex;
+        use vmm_common::storage::Storage;
+
+        use crate::{
+            cgroup::SandboxCgroup,
+            container::KuasarContainer,
+            device::{BusType, DeviceInfo},
+            sandbox::{KuasarSandbox, KuasarSandboxer, SandboxConfig},
+            vm::{Hooks, Pids, Recoverable, VMFactory, VcpuThreads, VM},
+        };
+
+        #[derive(Default, Serialize, Deserialize)]
+        struct MockVM {
+            fail_recover: bool,
+            socket_address: String,
+            stop_marker: String,
+        }
+
+        #[async_trait]
+        impl VM for MockVM {
+            async fn start(&mut self) -> Result<u32> {
+                Ok(0)
+            }
+
+            async fn stop(&mut self, force: bool) -> Result<()> {
+                let content = if force { "force" } else { "graceful" };
+                if !self.stop_marker.is_empty() {
+                    tokio::fs::write(&self.stop_marker, content)
+                        .await
+                        .map_err(containerd_sandbox::error::Error::IO)?;
+                }
+                Ok(())
+            }
+
+            async fn attach(&mut self, _device_info: DeviceInfo) -> Result<()> {
+                Ok(())
+            }
+
+            async fn hot_attach(&mut self, _device_info: DeviceInfo) -> Result<(BusType, String)> {
+                Ok((BusType::PCI, String::new()))
+            }
+
+            async fn hot_detach(&mut self, _id: &str) -> Result<()> {
+                Ok(())
+            }
+
+            async fn ping(&self) -> Result<()> {
+                Ok(())
+            }
+
+            fn socket_address(&self) -> String {
+                self.socket_address.clone()
+            }
+
+            async fn wait_channel(&self) -> Option<tokio::sync::watch::Receiver<(u32, i128)>> {
+                None
+            }
+
+            async fn vcpus(&self) -> Result<VcpuThreads> {
+                Ok(VcpuThreads {
+                    vcpus: HashMap::new(),
+                })
+            }
+
+            fn pids(&self) -> Pids {
+                Pids::default()
+            }
+        }
+
+        #[async_trait]
+        impl Recoverable for MockVM {
+            async fn recover(&mut self) -> Result<()> {
+                if self.fail_recover {
+                    return Err(containerd_sandbox::error::Error::InvalidArgument(
+                        "mock recover failure".to_string(),
+                    ));
+                }
+                Ok(())
+            }
+        }
+
+        struct MockFactory;
+
+        #[async_trait]
+        impl VMFactory for MockFactory {
+            type VM = MockVM;
+            type Config = ();
+
+            fn new(_: Self::Config) -> Self {
+                Self
+            }
+
+            async fn create_vm(&self, _: &str, _: &SandboxOption) -> Result<Self::VM> {
+                Ok(MockVM::default())
+            }
+        }
+
+        struct MockHooks;
+
+        #[async_trait]
+        impl Hooks<MockVM> for MockHooks {}
+
+        fn mock_sandbox(
+            base_dir: &str,
+            status: SandboxStatus,
+            vm: MockVM,
+        ) -> KuasarSandbox<MockVM> {
+            KuasarSandbox {
+                vm,
+                id: "test-sandbox".to_string(),
+                status,
+                base_dir: base_dir.to_string(),
+                data: SandboxData::default(),
+                containers: HashMap::<String, KuasarContainer>::new(),
+                storages: Vec::<Storage>::new(),
+                id_generator: 0,
+                network: None,
+                client: Arc::new(Mutex::new(None)),
+                exit_signal: Arc::new(ExitSignal::default()),
+                sandbox_cgroups: SandboxCgroup::default(),
+            }
+        }
+
+        async fn write_dump<P: AsRef<Path>>(dir: P, sandbox: &KuasarSandbox<MockVM>) {
+            let dump_path = dir.as_ref().join("sandbox.json");
+            let content = serde_json::to_vec(sandbox).unwrap();
+            tokio::fs::write(dump_path, content).await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_recover_fast_fail_paths_force_stop_vm() {
+            let cases = vec![
+                (
+                    "recover-error",
+                    MockVM {
+                        fail_recover: true,
+                        socket_address: "vsock://ignored".to_string(),
+                        stop_marker: String::new(),
+                    },
+                ),
+                (
+                    "init-client-error",
+                    MockVM {
+                        fail_recover: false,
+                        socket_address: String::new(),
+                        stop_marker: String::new(),
+                    },
+                ),
+            ];
+
+            for (name, mut vm) in cases {
+                let temp_dir = TempDir::new().unwrap();
+                let stop_marker = temp_dir.path().join(format!("{name}.stop"));
+                vm.stop_marker = stop_marker.to_string_lossy().to_string();
+
+                let sandbox = mock_sandbox(
+                    temp_dir.path().to_str().unwrap(),
+                    SandboxStatus::Running(42),
+                    vm,
+                );
+                write_dump(temp_dir.path(), &sandbox).await;
+
+                let result = KuasarSandbox::<MockVM>::recover(temp_dir.path()).await;
+                assert!(result.is_err(), "{name} should fail fast");
+
+                let marker_content = tokio::fs::read_to_string(&stop_marker).await.unwrap();
+                assert_eq!(marker_content, "force", "{name} should force stop the VM");
+            }
+        }
+
+        #[tokio::test]
+        async fn test_sandboxer_recover_cleans_failed_sandbox_dir() {
+            let root = TempDir::new().unwrap();
+            let failed_dir = root.path().join("failed");
+            tokio::fs::create_dir_all(&failed_dir).await.unwrap();
+            let stop_marker = root.path().join("failed.stop");
+
+            let sandbox = mock_sandbox(
+                failed_dir.to_str().unwrap(),
+                SandboxStatus::Running(7),
+                MockVM {
+                    fail_recover: true,
+                    socket_address: "vsock://ignored".to_string(),
+                    stop_marker: stop_marker.to_string_lossy().to_string(),
+                },
+            );
+            write_dump(&failed_dir, &sandbox).await;
+
+            let mut sandboxer = KuasarSandboxer::<MockFactory, MockHooks>::new(
+                SandboxConfig::default(),
+                (),
+                MockHooks,
+            );
+            sandboxer.recover(root.path().to_str().unwrap()).await;
+
+            assert!(
+                tokio::fs::metadata(&failed_dir).await.is_err(),
+                "failed sandbox dir should be removed after fast failure"
+            );
+            assert_eq!(
+                tokio::fs::read_to_string(&stop_marker).await.unwrap(),
+                "force"
+            );
+            assert!(sandboxer.sandboxes.read().await.is_empty());
+        }
+    }
+
     mod dns {
         use crate::sandbox::parse_dnsoptions;
 


### PR DESCRIPTION
### Background
When a node hosts multiple abnormal sandboxes (e.g., after `vmm-task` crash), the current sequential recovery process can block the `kuasar-vmm` service for several minutes. This is because the recovery logic involves time-consuming operations like VM state restoration and agent connection checks. During this period, the service is unavailable to handle new requests or manage healthy sandboxes.

### Proposed Changes
- **Concurrent Recovery**: Implemented parallel sandbox recovery in `KuasarSandboxer::recover` using `tokio::spawn` with a concurrency limit of 32 to reduce start-up latency.
- **Fail-fast & Cleanup**: Refactored `KuasarSandbox::recover` to fast-fail on fatal recovery or connection errors. Failed sandboxes are now properly force-stopped and their metadata directories are cleaned up to prevent resource leaks and inconsistent state.
- **Improved Observability**: Added detailed logs for recovery tasks to help diagnose sandbox state during node initialization.