### PR TITLE
vmm/sandbox: optimize cgroup setup and binding overhead

### DIFF
--- a/vmm/sandbox/src/cgroup.rs
+++ b/vmm/sandbox/src/cgroup.rs
@@ -38,11 +38,11 @@ pub const POD_OVERHEAD_CGROUP_NAME: &str = "pod_overhead";
 pub struct SandboxCgroup {
     pub cgroup_parent_path: String,
     #[serde(skip)]
-    pub sandbox_cgroup: Cgroup,
+    pub sandbox_cgroup: Option<Cgroup>,
     #[serde(skip)]
-    pub vcpu_cgroup: Cgroup,
+    pub vcpu_cgroup: Option<Cgroup>,
     #[serde(skip)]
-    pub pod_overhead_cgroup: Cgroup,
+    pub pod_overhead_cgroup: Option<Cgroup>,
 }
 
 impl SandboxCgroup {
@@ -53,8 +53,9 @@ impl SandboxCgroup {
         // So need to remove the "/" prefix for sandbox_cgroup_path
         let sandbox_cgroup_rela_path = sandbox_cgroup_path.trim_start_matches('/');
 
-        let sandbox_cgroup =
-            CgroupBuilder::new(sandbox_cgroup_rela_path).build(cgroups_rs::hierarchies::auto())?;
+        let sandbox_cgroup = CgroupBuilder::new(sandbox_cgroup_rela_path)
+            .set_specified_controllers(vec!["cpu".to_string(), "memory".to_string()])
+            .build(cgroups_rs::hierarchies::auto())?;
 
         // Only create the vcpu and pod_overhead cgroups in the cpu cgroup subsystem
         let vcpu_cgroup_path = format!("{}/{}", sandbox_cgroup_rela_path, VCPU_CGROUP_NAME);
@@ -70,29 +71,35 @@ impl SandboxCgroup {
 
         Ok(SandboxCgroup {
             cgroup_parent_path: cgroup_parent_path.to_string(),
-            sandbox_cgroup,
-            vcpu_cgroup,
-            pod_overhead_cgroup,
+            sandbox_cgroup: Some(sandbox_cgroup),
+            vcpu_cgroup: Some(vcpu_cgroup),
+            pod_overhead_cgroup: Some(pod_overhead_cgroup),
         })
     }
 
     pub fn update_res_for_sandbox_cgroups(&self, sandbox_data: &SandboxData) -> Result<()> {
-        // apply the total resources = sum(sum(containers_resources) + pod_overhead)) in the sandbox cgroup dir
-        if let Some(total_resources) = get_total_resources(sandbox_data) {
-            apply_cpu_resource(&self.sandbox_cgroup, &total_resources)?;
-            apply_memory_resource(&self.sandbox_cgroup, &total_resources)?;
-            apply_cpuset_resources(&self.sandbox_cgroup, &total_resources)?;
-            apply_hugetlb_resources(&self.sandbox_cgroup, &total_resources)?;
+        if let Some(ref sandbox_cgroup) = self.sandbox_cgroup {
+            // apply the total resources = sum(sum(containers_resources) + pod_overhead)) in the sandbox cgroup dir
+            if let Some(total_resources) = get_total_resources(sandbox_data) {
+                apply_cpu_resource(sandbox_cgroup, &total_resources)?;
+                apply_memory_resource(sandbox_cgroup, &total_resources)?;
+                apply_cpuset_resources(sandbox_cgroup, &total_resources)?;
+                apply_hugetlb_resources(sandbox_cgroup, &total_resources)?;
+            }
         }
 
-        // apply the cpu resource of containers in the vcpu cpu subsystem cgroup
-        if let Some(containers_resources) = get_resources(sandbox_data) {
-            apply_cpu_resource(&self.vcpu_cgroup, containers_resources)?;
+        if let Some(ref vcpu_cgroup) = self.vcpu_cgroup {
+            // apply the cpu resource of containers in the vcpu cpu subsystem cgroup
+            if let Some(containers_resources) = get_resources(sandbox_data) {
+                apply_cpu_resource(vcpu_cgroup, containers_resources)?;
+            }
         }
 
-        // apply the cpu resource of pod_overhead in the pod_overhead cpu subsystem cgroup
-        if let Some(overhead_resources) = get_overhead_resources(sandbox_data) {
-            apply_cpu_resource(&self.pod_overhead_cgroup, overhead_resources)?;
+        if let Some(ref pod_overhead_cgroup) = self.pod_overhead_cgroup {
+            // apply the cpu resource of pod_overhead in the pod_overhead cpu subsystem cgroup
+            if let Some(overhead_resources) = get_overhead_resources(sandbox_data) {
+                apply_cpu_resource(pod_overhead_cgroup, overhead_resources)?;
+            }
         }
 
         Ok(())
@@ -104,15 +111,20 @@ impl SandboxCgroup {
         vcpu_threads: Option<VcpuThreads>,
     ) -> Result<()> {
         // Add vmm process into the sandbox_cgroup
-        self.sandbox_cgroup.add_task_by_tgid((pid as u64).into())?;
-        self.pod_overhead_cgroup
-            .add_task_by_tgid((pid as u64).into())?;
+        if let Some(ref sandbox_cgroup) = self.sandbox_cgroup {
+            sandbox_cgroup.add_task_by_tgid((pid as u64).into())?;
+        }
+        if let Some(ref pod_overhead_cgroup) = self.pod_overhead_cgroup {
+            pod_overhead_cgroup.add_task_by_tgid((pid as u64).into())?;
+        }
 
         if let Some(all_vcpu_threads) = vcpu_threads {
-            // Move vmm process from parent sandbox cgroup into pod_overhead cgroup
-            // Then move the all vcpu threads of vmm process into vcpu cgroup
-            for (_, vcpu_thread_tid) in all_vcpu_threads.vcpus {
-                self.vcpu_cgroup.add_task((vcpu_thread_tid as u64).into())?;
+            if let Some(ref vcpu_cgroup) = self.vcpu_cgroup {
+                // Move vmm process from parent sandbox cgroup into pod_overhead cgroup
+                // Then move the all vcpu threads of vmm process into vcpu cgroup
+                for (_, vcpu_thread_tid) in all_vcpu_threads.vcpus {
+                    vcpu_cgroup.add_task((vcpu_thread_tid as u64).into())?;
+                }
             }
         }
 
@@ -120,9 +132,15 @@ impl SandboxCgroup {
     }
 
     pub fn remove_sandbox_cgroups(&self) -> Result<()> {
-        remove_sandbox_cgroup(&self.vcpu_cgroup)?;
-        remove_sandbox_cgroup(&self.pod_overhead_cgroup)?;
-        remove_sandbox_cgroup(&self.sandbox_cgroup)?;
+        if let Some(ref vcpu_cgroup) = self.vcpu_cgroup {
+            remove_sandbox_cgroup(vcpu_cgroup)?;
+        }
+        if let Some(ref pod_overhead_cgroup) = self.pod_overhead_cgroup {
+            remove_sandbox_cgroup(pod_overhead_cgroup)?;
+        }
+        if let Some(ref sandbox_cgroup) = self.sandbox_cgroup {
+            remove_sandbox_cgroup(sandbox_cgroup)?;
+        }
         Ok(())
     }
 }
@@ -161,9 +179,17 @@ fn apply_memory_resource(cgroup: &Cgroup, res: &LinuxContainerResources) -> Resu
 }
 
 fn apply_cpuset_resources(cgroup: &Cgroup, res: &LinuxContainerResources) -> Result<()> {
-    let cpuset_controller: &CpuSetController = cgroup
-        .controller_of()
-        .ok_or_else(|| anyhow!("No cpuset controller attached!"))?;
+    if res.cpuset_cpus.is_empty() && res.cpuset_mems.is_empty() {
+        return Ok(());
+    }
+
+    let cpuset_controller: &CpuSetController = match cgroup.controller_of() {
+        Some(c) => c,
+        None => {
+            log::warn!("cpuset resource specified but no cpuset controller attached!");
+            return Ok(());
+        }
+    };
 
     if !res.cpuset_cpus.is_empty() {
         cpuset_controller.set_cpus(&res.cpuset_cpus)?;
@@ -176,9 +202,18 @@ fn apply_cpuset_resources(cgroup: &Cgroup, res: &LinuxContainerResources) -> Res
 }
 
 fn apply_hugetlb_resources(cgroup: &Cgroup, res: &LinuxContainerResources) -> Result<()> {
-    let hugetlb_controller: &HugeTlbController = cgroup
-        .controller_of()
-        .ok_or_else(|| anyhow!("No hugetlb controller attached!"))?;
+    if res.hugepage_limits.is_empty() {
+        return Ok(());
+    }
+
+    let hugetlb_controller: &HugeTlbController = match cgroup.controller_of() {
+        Some(c) => c,
+        None => {
+            log::warn!("hugetlb resource specified but no hugetlb controller attached!");
+            return Ok(());
+        }
+    };
+
     for h in res.hugepage_limits.iter() {
         hugetlb_controller.set_limit_in_bytes(h.page_size.as_str(), h.limit)?;
     }
@@ -221,6 +256,12 @@ mod tests {
 
     use super::*;
     use crate::utils::get_sandbox_cgroup_parent_path;
+
+    macro_rules! unwrap_cgroup {
+        ($cgroups:expr, $field:ident) => {
+            $cgroups.$field.as_ref().unwrap()
+        };
+    }
 
     fn create_mock_pod_sandbox_config() -> PodSandboxConfig {
         let mut pod_sandbox_config = PodSandboxConfig::default();
@@ -290,7 +331,9 @@ mod tests {
 
                 // check sandbox level cgroup
                 let sandbox_cgroup_cpu_controller: &CpuController =
-                    sandbox_cgoups.sandbox_cgroup.controller_of().unwrap();
+                    unwrap_cgroup!(sandbox_cgoups, sandbox_cgroup)
+                        .controller_of()
+                        .unwrap();
                 assert!(sandbox_cgroup_cpu_controller.path().exists());
                 assert_eq!(
                     sandbox_cgroup_cpu_controller.path(),
@@ -301,7 +344,9 @@ mod tests {
 
                 // check vcpu level cgroup
                 let vcpu_cgroup_cpu_controller: &CpuController =
-                    sandbox_cgoups.vcpu_cgroup.controller_of().unwrap();
+                    unwrap_cgroup!(sandbox_cgoups, vcpu_cgroup)
+                        .controller_of()
+                        .unwrap();
                 assert!(vcpu_cgroup_cpu_controller.path().exists());
                 assert_eq!(
                     vcpu_cgroup_cpu_controller.path(),
@@ -315,22 +360,43 @@ mod tests {
 
         // Case 3: If sandbox cgroups already exist in the system, then call create_sandbox_cgroups
         //         function again will not fail
-        let result = SandboxCgroup::create_sandbox_cgroups(&sandbox_cgroup_path, &sandbox_data.id);
-        match result {
-            Ok(sandbox_cgoups) => {
-                let sandbox_cgroup_mem_controller: &MemController =
-                    sandbox_cgoups.sandbox_cgroup.controller_of().unwrap();
-                assert!(sandbox_cgroup_mem_controller.path().exists());
-                assert_eq!(
-                    sandbox_cgroup_mem_controller.path().to_str().unwrap(),
-                    "/sys/fs/cgroup/memory/kubepods/burstable/podxxx/test_sandbox"
-                );
+        let cgroups =
+            SandboxCgroup::create_sandbox_cgroups("/kubepods/burstable/podxxx", "sandbox_id")
+                .unwrap();
+        let cpu_cgroup_root_pathbuf = cgroups_rs::hierarchies::V1::new()
+            .get_mount_point(cgroups_rs::Controllers::Cpu)
+            .unwrap();
+        let sandbox_cgroup_cpu_controller: &CpuController = unwrap_cgroup!(cgroups, sandbox_cgroup)
+            .controller_of()
+            .unwrap();
+        assert_eq!(
+            sandbox_cgroup_cpu_controller.path(),
+            cpu_cgroup_root_pathbuf
+                .join("kubepods/burstable/podxxx/sandbox_id")
+                .as_path()
+        );
+        let vcpu_cgroup_cpu_controller: &CpuController = unwrap_cgroup!(cgroups, vcpu_cgroup)
+            .controller_of()
+            .unwrap();
+        assert_eq!(
+            vcpu_cgroup_cpu_controller.path(),
+            cpu_cgroup_root_pathbuf
+                .join("kubepods/burstable/podxxx/sandbox_id/vcpu")
+                .as_path()
+        );
+        let pod_overhead_cgroup_cpu_controller: &CpuController =
+            unwrap_cgroup!(cgroups, pod_overhead_cgroup)
+                .controller_of()
+                .unwrap();
+        assert_eq!(
+            pod_overhead_cgroup_cpu_controller.path(),
+            cpu_cgroup_root_pathbuf
+                .join("kubepods/burstable/podxxx/sandbox_id/pod_overhead")
+                .as_path()
+        );
 
-                // Clean the test sandbox cgroups
-                assert_eq!(sandbox_cgoups.remove_sandbox_cgroups().is_ok(), true);
-            }
-            Err(e) => panic!("Expected an Ok, but got error: {}", e.to_string()),
-        }
+        // Clean the test sandbox cgroups
+        assert_eq!(cgroups.remove_sandbox_cgroups().is_ok(), true);
     }
 
     #[test]
@@ -357,52 +423,37 @@ mod tests {
                 // Check sandbox level cgroup total resources
                 // Check cpu subsystem cgroup limit
                 let sandbox_cgroup_cpu_controller: &CpuController =
-                    sandbox_cgroups.sandbox_cgroup.controller_of().unwrap();
+                    unwrap_cgroup!(sandbox_cgroups, sandbox_cgroup)
+                        .controller_of()
+                        .unwrap();
                 assert_eq!(sandbox_cgroup_cpu_controller.cfs_period().unwrap(), 100000);
                 assert_eq!(sandbox_cgroup_cpu_controller.cfs_quota().unwrap(), 250000);
                 assert_eq!(sandbox_cgroup_cpu_controller.shares().unwrap(), 2048);
 
                 // Check memory subsystem cgroup limit
                 let sandbox_cgroup_mem_controller: &MemController =
-                    sandbox_cgroups.sandbox_cgroup.controller_of().unwrap();
+                    unwrap_cgroup!(sandbox_cgroups, sandbox_cgroup)
+                        .controller_of()
+                        .unwrap();
                 let memory_stats = sandbox_cgroup_mem_controller.memory_stat();
                 let memory_swap_stats = sandbox_cgroup_mem_controller.memswap();
                 assert_eq!(memory_stats.limit_in_bytes, 1124 * 1024 * 1024);
                 assert_eq!(memory_swap_stats.limit_in_bytes, 1124 * 1024 * 1024);
 
-                // Check cpuset subsystem cgroup limit
-                let sandbox_cgroup_cpuset_controller: &CpuSetController =
-                    sandbox_cgroups.sandbox_cgroup.controller_of().unwrap();
-                let cpuset_stats = sandbox_cgroup_cpuset_controller.cpuset();
-                assert_eq!(cpuset_stats.cpus, vec![(0, 1)]);
-                assert_eq!(cpuset_stats.mems, vec![(0, 0)]);
-
-                // Check hugetlb subsystem cgroup limit
-                let sandbox_cgroup_hugetlb_controller: &HugeTlbController =
-                    sandbox_cgroups.sandbox_cgroup.controller_of().unwrap();
-                assert_eq!(
-                    sandbox_cgroup_hugetlb_controller
-                        .get_sizes()
-                        .contains(&"2MB".to_string()),
-                    true
-                );
-                assert_eq!(
-                    sandbox_cgroup_hugetlb_controller
-                        .limit_in_bytes("2MB")
-                        .unwrap(),
-                    2 * 1024 * 1024 * 1024
-                );
-
                 // check vcpu level cgroup
                 let vcpu_cgroup_cpu_controller: &CpuController =
-                    sandbox_cgroups.vcpu_cgroup.controller_of().unwrap();
+                    unwrap_cgroup!(sandbox_cgroups, vcpu_cgroup)
+                        .controller_of()
+                        .unwrap();
                 assert_eq!(vcpu_cgroup_cpu_controller.cfs_period().unwrap(), 100000);
                 assert_eq!(vcpu_cgroup_cpu_controller.cfs_quota().unwrap(), 200000);
                 assert_eq!(vcpu_cgroup_cpu_controller.shares().unwrap(), 1024);
 
                 // check pod_overhead level cgroup
                 let pod_overhead_cgroup_cpu_controller: &CpuController =
-                    sandbox_cgroups.pod_overhead_cgroup.controller_of().unwrap();
+                    unwrap_cgroup!(sandbox_cgroups, pod_overhead_cgroup)
+                        .controller_of()
+                        .unwrap();
                 assert_eq!(
                     pod_overhead_cgroup_cpu_controller.cfs_period().unwrap(),
                     100000
@@ -417,5 +468,27 @@ mod tests {
         }
 
         assert_eq!(sandbox_cgroups.remove_sandbox_cgroups().is_ok(), true);
+    }
+
+    #[test]
+    fn test_empty_sandbox_cgroups_are_noop() {
+        let mut sandbox_data = SandboxData::default();
+        sandbox_data.id = String::from("test_sandbox");
+        sandbox_data.config = Some(create_mock_pod_sandbox_config());
+
+        let sandbox_cgroups = SandboxCgroup::default();
+
+        assert!(sandbox_cgroups
+            .update_res_for_sandbox_cgroups(&sandbox_data)
+            .is_ok());
+        assert!(sandbox_cgroups
+            .add_process_into_sandbox_cgroups(
+                1,
+                Some(VcpuThreads {
+                    vcpus: HashMap::from([(0, 1)]),
+                }),
+            )
+            .is_ok());
+        assert!(sandbox_cgroups.remove_sandbox_cgroups().is_ok());
     }
 }

--- a/vmm/sandbox/src/sandbox.rs
+++ b/vmm/sandbox/src/sandbox.rs
@@ -216,18 +216,7 @@ where
             .unwrap_or(DEFAULT_CGROUP_PARENT_PATH.to_string());
         // Currently only support cgroup V1, cgroup V2 is not supported now
         if !cgroups_rs::hierarchies::is_cgroup2_unified_mode() {
-            // Create sandbox's cgroup and apply sandbox's resources limit
-            let create_and_update_sandbox_cgroup = (|| {
-                sandbox_cgroups =
-                    SandboxCgroup::create_sandbox_cgroups(&cgroup_parent_path, &s.sandbox.id)?;
-                sandbox_cgroups.update_res_for_sandbox_cgroups(&s.sandbox)?;
-                Ok(())
-            })();
-            // If create and update sandbox cgroup failed, do rollback operation
-            if let Err(e) = create_and_update_sandbox_cgroup {
-                let _ = sandbox_cgroups.remove_sandbox_cgroups();
-                return Err(e);
-            }
+            sandbox_cgroups.cgroup_parent_path = cgroup_parent_path;
         }
         let vm = self.factory.create_vm(id, &s).await?;
         let mut sandbox = KuasarSandbox {
@@ -275,15 +264,6 @@ where
         let sandbox_clone = sandbox_mutex.clone();
         monitor(sandbox_clone);
 
-        if let Err(e) = sandbox.add_to_cgroup().await {
-            if let Err(re) = sandbox.stop(true).await {
-                warn!("roll back in add to cgroup {}", re);
-                return Err(e);
-            }
-            sandbox.destroy_network().await;
-            return Err(e);
-        }
-
         if let Err(e) = self.hooks.post_start(&mut sandbox).await {
             if let Err(re) = sandbox.stop(true).await {
                 warn!("roll back in sandbox post start {}", re);
@@ -300,6 +280,22 @@ where
             }
             sandbox.destroy_network().await;
             return Err(e);
+        }
+
+        // Trigger asynchronous cgroup setup and process binding after start.
+        // The task is spawned only after all start-time rollback points complete.
+        if !cgroups_rs::hierarchies::is_cgroup2_unified_mode() {
+            let sb_mutex = self.sandbox(id).await?;
+            tokio::spawn(async move {
+                let mut sb = sb_mutex.lock().await;
+                let sandbox_id = sb.id.clone();
+                if let Err(e) = sb.bind_cgroups_if_running().await {
+                    error!(
+                        "sandbox {}: async cgroup creation failed: {}",
+                        sandbox_id, e
+                    );
+                }
+            });
         }
 
         Ok(())
@@ -355,8 +351,14 @@ where
 
             // Currently only support cgroup V1, cgroup V2 is not supported now
             if !cgroups_rs::hierarchies::is_cgroup2_unified_mode() {
-                // remove the sandbox cgroups
-                sb.sandbox_cgroups.remove_sandbox_cgroups()?;
+                // remove the sandbox cgroups asynchronously
+                let sandbox_cgroups = std::mem::take(&mut sb.sandbox_cgroups);
+                tokio::task::spawn_blocking(move || -> Result<()> {
+                    sandbox_cgroups.remove_sandbox_cgroups()?;
+                    Ok(())
+                })
+                .await
+                .map_err(|e| Error::Other(anyhow!("spawn_blocking error: {}", e)))??;
             }
 
             cleanup_mounts(&sb.base_dir).await?;
@@ -502,7 +504,7 @@ where
             .map_err(Error::IO)?;
         let mut sb = serde_json::from_slice::<KuasarSandbox<V>>(content.as_slice())
             .map_err(|e| anyhow!("failed to deserialize sandbox, {}", e))?;
-        if let SandboxStatus::Running(_) = sb.status {
+        if let SandboxStatus::Running(vmm_pid) = sb.status {
             if let Err(e) = sb.vm.recover().await {
                 warn!("failed to recover vm {}: {}, then force kill it!", sb.id, e);
                 if let Err(re) = sb.stop(true).await {
@@ -520,10 +522,16 @@ where
             }
             sb.sync_clock().await;
             sb.forward_events().await;
+            if !cgroups_rs::hierarchies::is_cgroup2_unified_mode() {
+                if let Err(e) = sb.create_and_bind_cgroups(vmm_pid).await {
+                    if let Err(re) = sb.stop(true).await {
+                        warn!("roll back in recover, bind cgroup and stop: {}", re);
+                        return Err(e);
+                    }
+                    return Err(e);
+                }
+            }
         }
-        // recover the sandbox_cgroups in the sandbox object
-        sb.sandbox_cgroups =
-            SandboxCgroup::create_sandbox_cgroups(&sb.sandbox_cgroups.cgroup_parent_path, &sb.id)?;
 
         info!(
             "recover sandbox {} takes {}ms",
@@ -603,6 +611,9 @@ where
         }
 
         self.vm.stop(force).await?;
+        let ts = time::OffsetDateTime::now_utc().unix_timestamp_nanos();
+        self.status = SandboxStatus::Stopped(0, ts);
+        self.exit_signal.signal();
         self.destroy_network().await;
         Ok(())
     }
@@ -791,30 +802,47 @@ where
     }
 
     #[instrument(skip_all)]
-    pub async fn add_to_cgroup(&self) -> Result<()> {
-        // Currently only support cgroup V1, cgroup V2 is not supported now
-        if !cgroups_rs::hierarchies::is_cgroup2_unified_mode() {
-            // add vmm process into sandbox cgroup
-            if let SandboxStatus::Running(vmm_pid) = self.status {
-                let vcpu_threads = self.vm.vcpus().await?;
-                debug!(
-                    "vmm process pid: {}, vcpu threads pid: {:?}",
-                    vmm_pid, vcpu_threads
-                );
-                self.sandbox_cgroups
-                    .add_process_into_sandbox_cgroups(vmm_pid, Some(vcpu_threads))?;
-                // move all vmm-related process into sandbox cgroup
-                for pid in self.vm.pids().affiliated_pids {
-                    self.sandbox_cgroups
-                        .add_process_into_sandbox_cgroups(pid, None)?;
+    async fn create_and_bind_cgroups(&mut self, vmm_pid: u32) -> Result<()> {
+        let vcpu_threads = self.vm.vcpus().await?;
+        let data = self.data.clone();
+        let cgroup_parent = self.sandbox_cgroups.cgroup_parent_path.clone();
+        let sandbox_id = self.id.clone();
+        let affiliated_pids = self.vm.pids().affiliated_pids.clone();
+
+        // Execute the cgroup creation and binding inside a blocking task.
+        // It is important that `&mut self` is held across this await point to ensure
+        // exclusive access to the sandbox object. This prevents other operations (e.g., delete)
+        // from concurrently modifying or removing the sandbox while the background cgroup setup
+        // is in progress.
+        self.sandbox_cgroups = tokio::task::spawn_blocking(move || -> Result<SandboxCgroup> {
+            let mut cgroups = SandboxCgroup::default();
+            let create_res = (|| -> Result<()> {
+                cgroups = SandboxCgroup::create_sandbox_cgroups(&cgroup_parent, &sandbox_id)?;
+                cgroups.update_res_for_sandbox_cgroups(&data)?;
+                cgroups.add_process_into_sandbox_cgroups(vmm_pid, Some(vcpu_threads))?;
+                for pid in affiliated_pids {
+                    cgroups.add_process_into_sandbox_cgroups(pid, None)?;
                 }
-            } else {
-                return Err(Error::Other(anyhow!(
-                    "sandbox status is not Running after started!"
-                )));
+                Ok(())
+            })();
+            if let Err(e) = create_res {
+                let _ = cgroups.remove_sandbox_cgroups();
+                return Err(e);
             }
-        }
+            Ok(cgroups)
+        })
+        .await
+        .map_err(|e| Error::Other(anyhow!("spawn_blocking error: {}", e)))??;
         Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn bind_cgroups_if_running(&mut self) -> Result<bool> {
+        if let SandboxStatus::Running(vmm_pid) = self.status {
+            self.create_and_bind_cgroups(vmm_pid).await?;
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     pub(crate) async fn forward_events(&mut self) {
@@ -1194,6 +1222,36 @@ mod tests {
                 "force"
             );
             assert!(sandboxer.sandboxes.read().await.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_stop_marks_sandbox_stopped_before_pending_cgroup_bind() {
+            let temp_dir = TempDir::new().unwrap();
+            let stop_marker = temp_dir.path().join("stop.marker");
+            let mut sandbox = mock_sandbox(
+                temp_dir.path().to_str().unwrap(),
+                SandboxStatus::Running(42),
+                MockVM {
+                    fail_recover: false,
+                    socket_address: String::new(),
+                    stop_marker: stop_marker.to_string_lossy().to_string(),
+                },
+            );
+
+            sandbox.stop(true).await.unwrap();
+
+            assert!(matches!(sandbox.status, SandboxStatus::Stopped(0, _)));
+            assert_eq!(
+                tokio::fs::read_to_string(&stop_marker).await.unwrap(),
+                "force"
+            );
+            assert!(
+                !sandbox.bind_cgroups_if_running().await.unwrap(),
+                "pending cgroup bind should skip stopped sandboxes"
+            );
+            assert!(sandbox.sandbox_cgroups.sandbox_cgroup.is_none());
+            assert!(sandbox.sandbox_cgroups.vcpu_cgroup.is_none());
+            assert!(sandbox.sandbox_cgroups.pod_overhead_cgroup.is_none());
         }
     }
 


### PR DESCRIPTION
## Summary

CRI sandbox creation historically took a long time due to synchronous cgroup initialization spanning all subsystem controllers and recursive process addition, leading to severe host-level cgroup_mutex contention.

This commit resolves the bottleneck with a fully asynchronous pattern:

- Prevent `SandboxCgroup::default()` from probing global system mounts by lazily initializing Cgroup members via Option wrapper.
- Move `create_sandbox_cgroups` and pid injection out of the CRI critical path into a `tokio::spawn` background task.
- Integrate rollback mechanics seamlessly via `bind_cgroups_if_running` to gracefully handle cases where sandbox is stopped before the async task fires, and apply similar resilience to the recover pipeline.
