### PR TITLE
fix: filter IPv6 link-local addresses and routes from host netns

### DIFF
--- a/vmm/sandbox/src/network/link.rs
+++ b/vmm/sandbox/src/network/link.rs
@@ -268,6 +268,12 @@ impl NetworkInterface {
                     if address.is_loopback() {
                         intf.r#type = LinkType::Loopback;
                     }
+                    // Skip IPv6 link-local addresses (fe80::/10): the kernel
+                    // auto-generates them from the MAC address and they must
+                    // not be manually configured inside the guest.
+                    if Self::should_skip_ip_address(&address) {
+                        continue;
+                    }
                     intf.ip_addresses.push(IpNet::new(address, mask_len));
                 }
             }
@@ -287,6 +293,13 @@ impl NetworkInterface {
             }
         }
         Ok(intf)
+    }
+
+    fn should_skip_ip_address(address: &std::net::IpAddr) -> bool {
+        matches!(
+            address,
+            std::net::IpAddr::V6(v6) if super::is_ipv6_unicast_link_local(v6)
+        )
     }
 
     pub async fn init_cni_interface(&mut self) -> Result<()> {
@@ -618,7 +631,27 @@ async fn bind_device_to_driver(driver: &str, bdf: &str) -> Result<()> {
 mod tests {
     use std::process::Command;
 
-    use crate::network::link::create_tap_device;
+    use crate::network::link::{create_tap_device, NetworkInterface};
+
+    #[test]
+    fn skip_ipv6_link_local_addresses() {
+        assert!(NetworkInterface::should_skip_ip_address(
+            &"fe80::1".parse().unwrap()
+        ));
+        assert!(NetworkInterface::should_skip_ip_address(
+            &"febf::1".parse().unwrap()
+        ));
+
+        assert!(!NetworkInterface::should_skip_ip_address(
+            &"fec0::1".parse().unwrap()
+        ));
+        assert!(!NetworkInterface::should_skip_ip_address(
+            &"2001:db8::1".parse().unwrap()
+        ));
+        assert!(!NetworkInterface::should_skip_ip_address(
+            &"192.0.2.1".parse().unwrap()
+        ));
+    }
 
     #[test]
     fn add_tap_device_with_long_name() {

--- a/vmm/sandbox/src/network/mod.rs
+++ b/vmm/sandbox/src/network/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{
     fmt::{Debug, Display, Formatter},
+    net::Ipv6Addr,
     os::unix::prelude::AsRawFd,
     path::Path,
 };
@@ -41,6 +42,10 @@ mod convert;
 pub mod link;
 mod netlink;
 pub mod route;
+
+pub(crate) fn is_ipv6_unicast_link_local(addr: &Ipv6Addr) -> bool {
+    addr.is_unicast_link_local()
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Network {

--- a/vmm/sandbox/src/network/route.rs
+++ b/vmm/sandbox/src/network/route.rs
@@ -69,7 +69,14 @@ impl Route {
         for attribute in msg.attributes.into_iter() {
             match attribute {
                 RouteAttribute::Destination(v) => {
-                    let ip = convert_to_ip_address(v)?.to_string();
+                    let ip = convert_to_ip_address(v)?;
+                    // Skip IPv6 link-local routes (fe80::/10): kernel-generated
+                    // connected routes that must not be pushed to the guest.
+                    if let std::net::IpAddr::V6(v6) = ip {
+                        if super::is_ipv6_unicast_link_local(&v6) {
+                            return Err(anyhow!("skip: IPv6 link-local route ({}/{}), kernel-generated and must not be pushed to guest", v6, msg.header.destination_prefix_length).into());
+                        }
+                    }
                     route.dest = format!("{}/{}", ip, msg.header.destination_prefix_length);
                 }
                 RouteAttribute::Source(v) => {
@@ -89,5 +96,66 @@ impl Route {
             }
         }
         Ok(route)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv6Addr;
+
+    use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteHeader, RouteMessage};
+
+    use super::Route;
+
+    fn make_v6_route_msg(addr: Ipv6Addr, prefix_len: u8) -> RouteMessage {
+        let mut msg = RouteMessage::default();
+        msg.header.table = RouteHeader::RT_TABLE_MAIN;
+        msg.header.destination_prefix_length = prefix_len;
+        msg.attributes = vec![RouteAttribute::Destination(RouteAddress::Inet6(addr))];
+        msg
+    }
+
+    #[test]
+    fn link_local_route_fe80_is_skipped() {
+        let result =
+            Route::parse_from_message(make_v6_route_msg("fe80::1".parse().unwrap(), 64), &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("skip"));
+    }
+
+    #[test]
+    fn link_local_route_upper_edge_febf_is_skipped() {
+        // febf:: is the last address inside fe80::/10
+        let result =
+            Route::parse_from_message(make_v6_route_msg("febf::1".parse().unwrap(), 64), &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("skip"));
+    }
+
+    #[test]
+    fn non_link_local_v6_route_passes_filter() {
+        // 2001:db8:: is global unicast and must not be filtered
+        let result =
+            Route::parse_from_message(make_v6_route_msg("2001:db8::".parse().unwrap(), 32), &[]);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().dest, "2001:db8::/32");
+    }
+
+    #[test]
+    fn fec0_just_above_link_local_range_passes_filter() {
+        // fec0:: is the first address just outside fe80::/10
+        let result =
+            Route::parse_from_message(make_v6_route_msg("fec0::1".parse().unwrap(), 64), &[]);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().dest, "fec0::1/64");
+    }
+
+    #[test]
+    fn route_not_in_main_table_is_ignored() {
+        let mut msg = RouteMessage::default();
+        msg.header.table = 0; // RT_TABLE_UNSPEC
+        let result = Route::parse_from_message(msg, &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ignore"));
     }
 }


### PR DESCRIPTION
## Summary

Filter IPv6 link-local network configuration copied from the host network namespace into the sandbox.

This change excludes:

- IPv6 interface addresses in `fe80::/10`
- IPv6 destination routes in `fe80::/10`

## Motivation

IPv6 link-local addresses are scoped to a specific link/interface and are not portable across network namespaces. Copying host-side `fe80::/10` addresses or link-local destination routes into the sandbox can produce invalid or misleading guest network configuration.

If IPv6 is enabled inside the sandbox, the guest kernel should create its own link-local address for the guest-side interface instead of inheriting the host-side one.

## Notes

This intentionally filters only link-local interface addresses and destination routes. Routes whose next-hop/gateway is link-local are not treated as equivalent here, since those can have different semantics, such as IPv6 default routes using a link-local gateway.

## Testing

- Verified the changes compile.
- Verified the filtering logic covers `fe80::/10` for both interface addresses and destination routes.
